### PR TITLE
Fix/fix endless submitting

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="C:\Gradle\gradle-8.13" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,10 +3,6 @@
   <component name="ComposerSettings">
     <execution />
   </component>
-  <component name="DiscordProjectSettings">
-    <option name="show" value="ASK" />
-    <option name="description" value="" />
-  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/src/main/kotlin/dev/slne/surf/servertour/entry/EntryManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/entry/EntryManager.kt
@@ -130,6 +130,7 @@ object EntryManager {
                 it.description = poi.description
                 it.location = poi.location
                 it.updatedAt = poi.updatedAt
+                it.status = poi.status
             }
         }
     }
@@ -142,6 +143,7 @@ object EntryManager {
             it.description = entry.description
             it.updatedAt = entry.updatedAt
             it.location = entry.location
+            it.status = entry.status
         }
     }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/entry/TourEntry.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/entry/TourEntry.kt
@@ -41,23 +41,15 @@ data class TourEntry(
         _poi.addAll(pois)
 
     suspend fun submit() {
-        println("Submitting entry $this")
         if (!isDraft()) return
-        println("Entry is draft, submitting POIs...")
 
         poi.forEach { it.submit() }
-
-        println("All POIs submitted, submitting entry...")
 
         EntryManager.updateEntry(this) {
             it.status = EntryStatus.PENDING
         }
 
-        println("Entry submitted.")
-
         status = EntryStatus.PENDING
-
-        println("Entry status updated to PENDING.")
     }
 
     suspend fun accept() {

--- a/src/main/kotlin/dev/slne/surf/servertour/entry/TourEntry.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/entry/TourEntry.kt
@@ -41,15 +41,23 @@ data class TourEntry(
         _poi.addAll(pois)
 
     suspend fun submit() {
+        println("Submitting entry $this")
         if (!isDraft()) return
+        println("Entry is draft, submitting POIs...")
 
         poi.forEach { it.submit() }
+
+        println("All POIs submitted, submitting entry...")
 
         EntryManager.updateEntry(this) {
             it.status = EntryStatus.PENDING
         }
 
+        println("Entry submitted.")
+
         status = EntryStatus.PENDING
+
+        println("Entry status updated to PENDING.")
     }
 
     suspend fun accept() {


### PR DESCRIPTION
This pull request introduces several configuration and code updates, primarily focusing on improving project setup and enhancing the `TourEntry` submission process. The most significant changes include enabling commit message inspections, updating the Gradle configuration, removing unnecessary project settings, and adding status synchronization and debug logging to the entry submission workflow.

Project configuration updates:

* Enabled commit message inspection and naming convention checks in `.idea/vcs.xml` to enforce better commit practices.
* Set the Gradle home directory to `C:\Gradle\gradle-8.13` in `.idea/gradle.xml` to ensure consistent build tooling.
* Removed the unused `DiscordProjectSettings` component from `.idea/misc.xml` to clean up project configuration.

Entry status synchronization:

* Updated `EntryManager` methods in `EntryManager.kt` to synchronize the `status` property when updating entries from POIs or other entries, ensuring consistency. [[1]](diffhunk://#diff-cecd8c8d51c06eb1b57aad5f0f595bd86ab321554715b328d8146101723d3242R133) [[2]](diffhunk://#diff-cecd8c8d51c06eb1b57aad5f0f595bd86ab321554715b328d8146101723d3242R146)

Debug logging improvements:

* Added detailed debug `println` statements to the `submit` method in `TourEntry.kt` to trace the submission process and status changes for easier troubleshooting.