### PR TITLE
fix: display location coordinates of POI in OnePoiDialog and view tour + view poi for players

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.0.0-SNAPSHOT
+version=1.21.7-1.0.1-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt
@@ -6,6 +6,7 @@ import dev.slne.surf.servertour.commands.serverTourCommand
 import dev.slne.surf.servertour.database.tables.EntryTable
 import dev.slne.surf.servertour.database.tables.MemberTable
 import dev.slne.surf.servertour.database.tables.PoiTable
+import dev.slne.surf.servertour.view.viewManager
 import org.bukkit.plugin.java.JavaPlugin
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
@@ -36,10 +37,12 @@ class SurfServerTour : SuspendingJavaPlugin() {
 
     override suspend fun onEnableAsync() {
         serverTourCommand()
+
+        viewManager.startTask()
     }
 
     override suspend fun onDisableAsync() {
+        viewManager.shutdown()
         databaseManager.databaseProvider.disconnect()
     }
-
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt
@@ -37,7 +37,6 @@ class SurfServerTour : SuspendingJavaPlugin() {
 
     override suspend fun onEnableAsync() {
         serverTourCommand()
-
         viewManager.startTask()
     }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt
@@ -6,7 +6,9 @@ import dev.slne.surf.servertour.commands.serverTourCommand
 import dev.slne.surf.servertour.database.tables.EntryTable
 import dev.slne.surf.servertour.database.tables.MemberTable
 import dev.slne.surf.servertour.database.tables.PoiTable
+import dev.slne.surf.servertour.view.ViewListener
 import dev.slne.surf.servertour.view.viewManager
+import dev.slne.surf.surfapi.bukkit.api.event.register
 import org.bukkit.plugin.java.JavaPlugin
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
@@ -38,6 +40,8 @@ class SurfServerTour : SuspendingJavaPlugin() {
     override suspend fun onEnableAsync() {
         serverTourCommand()
         viewManager.startTask()
+
+        ViewListener().register()
     }
 
     override suspend fun onDisableAsync() {

--- a/src/main/kotlin/dev/slne/surf/servertour/commands/ServerTourCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/commands/ServerTourCommand.kt
@@ -8,6 +8,8 @@ import dev.slne.surf.servertour.utils.ServerTourPermissionRegistry
 fun serverTourCommand() = commandAPICommand("servertour") {
     withPermission(ServerTourPermissionRegistry.BASE)
 
+    serverTourViewExitCommand()
+
     playerExecutor { player, _ ->
         player.showDialog(serverTourDialog(player.uniqueId))
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/commands/ServerTourViewExitCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/commands/ServerTourViewExitCommand.kt
@@ -1,0 +1,30 @@
+package dev.slne.surf.servertour.commands
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.servertour.plugin
+import dev.slne.surf.servertour.view.viewManager
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+fun CommandAPICommand.serverTourViewExitCommand() = subcommand("exitView") {
+    playerExecutor { player, _ ->
+        plugin.launch {
+            val success = viewManager.exitView(player)
+
+            if (success) {
+                player.sendText {
+                    appendPrefix()
+                    success("Du hast die Ansicht verlassen und wurdest zurück teleportiert.")
+                }
+                return@launch
+            }
+
+            player.sendText {
+                appendPrefix()
+                error("Du befindest dich in keiner Ansicht.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
@@ -13,6 +13,7 @@ import dev.slne.surf.servertour.dialogs.own.poi.ownTourPoisDialog
 import dev.slne.surf.servertour.entry.EntryManager
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
+import dev.slne.surf.servertour.view.viewManager
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
@@ -118,8 +119,22 @@ fun ownTourDialog(
             }
 
             action(removeEntryButton(entry, editable))
+            action(viewButton(entry))
 
             exitAction(backButton())
+        }
+    }
+}
+
+private fun viewButton(entry: TourEntry) = actionButton {
+    label { text("Tour ansehen") }
+    tooltip { info("Teleportiert dich für 5 Sekunden zu deiner Tour") }
+
+    action {
+        playerCallback {
+            plugin.launch {
+                viewManager.viewTour(it, entry)
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
@@ -1,4 +1,5 @@
 @file:Suppress("UnstableApiUsage")
+@file:OptIn(NmsUseWithCaution::class)
 
 package dev.slne.surf.servertour.dialogs.own
 
@@ -16,8 +17,10 @@ import dev.slne.surf.servertour.plugin
 import dev.slne.surf.servertour.view.viewManager
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.clearDialogs
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.dialog.Dialog
@@ -86,7 +89,7 @@ fun ownTourDialog(
     base {
         title(buildOwnTourTitle(entry))
         externalTitle { text(entry.name) }
-        afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+        afterAction(DialogBase.DialogAfterAction.NONE)
 
         body {
             plainMessage(400) {
@@ -133,6 +136,7 @@ private fun viewButton(entry: TourEntry) = actionButton {
     action {
         playerCallback {
             plugin.launch {
+                it.clearDialogs()
                 viewManager.viewTour(it, entry)
             }
         }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
@@ -29,6 +29,21 @@ fun buildPoiBody(entry: TourEntry, poi: Poi) = buildText {
     }
     appendNewline(2)
 
+    variableKey("Position: ")
+    appendNewline()
+    variableKey("X: ")
+    variableValue(poi.location.x.toInt())
+    spacer(", ")
+    variableKey("Y: ")
+    variableValue(poi.location.y.toInt())
+    spacer(", ")
+    variableKey("Z: ")
+    variableValue(poi.location.z.toInt())
+    spacer(" in ")
+    variableKey("Welt: ")
+    variableValue(poi.location.world?.name ?: "Unbekannt")
+    appendNewline(2)
+
     variableKey("Beschreibung: ")
     appendNewline()
     variableValue(poi.description.ifBlank { "Keine Beschreibung vorhanden" })

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
@@ -93,7 +93,11 @@ fun onePoiDialog(
                 exitAction(backButton(entry, editable))
             }
         } else {
-            notice(backButton(entry, editable))
+            multiAction {
+                columns(2)
+                backButton(entry, editable)
+                action(viewButton(poi))
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
@@ -1,4 +1,5 @@
 @file:Suppress("UnstableApiUsage")
+@file:OptIn(NmsUseWithCaution::class)
 
 package dev.slne.surf.servertour.dialogs.own.poi
 
@@ -11,8 +12,10 @@ import dev.slne.surf.servertour.plugin
 import dev.slne.surf.servertour.view.viewManager
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.clearDialogs
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.dialog.Dialog
@@ -66,7 +69,7 @@ fun onePoiDialog(
         externalTitle {
             text(poi.name)
         }
-        afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+        afterAction(DialogBase.DialogAfterAction.NONE)
 
         body {
             plainMessage(400) {
@@ -102,6 +105,7 @@ private fun viewButton(poi: Poi) = actionButton {
     action {
         playerCallback {
             plugin.launch {
+                it.clearDialogs()
                 viewManager.viewPoi(it, poi)
             }
         }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.servertour.entry.EntryManager
 import dev.slne.surf.servertour.entry.Poi
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
+import dev.slne.surf.servertour.view.viewManager
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
@@ -84,11 +85,25 @@ fun onePoiDialog(
                 action(changeLocationButton(entry, poi, editable))
                 action(changeOwnerButton(entry, poi, editable))
                 action(removePoiButton(entry, poi, editable))
+                action(viewButton(poi))
 
                 exitAction(backButton(entry, editable))
             }
         } else {
             notice(backButton(entry, editable))
+        }
+    }
+}
+
+private fun viewButton(poi: Poi) = actionButton {
+    label { text("PoI Ansehen") }
+    tooltip { info("Teleportiert dich für 5 Sekunden zu diesem PoI") }
+
+    action {
+        playerCallback {
+            plugin.launch {
+                viewManager.viewPoi(it, poi)
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/utils/offline-player-util.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/utils/offline-player-util.kt
@@ -1,0 +1,89 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.utils
+
+import net.kyori.adventure.nbt.*
+import net.kyori.adventure.nbt.BinaryTagIO.Compression.GZIP
+import org.bukkit.Bukkit
+import org.bukkit.GameMode
+import org.bukkit.Location
+import org.bukkit.OfflinePlayer
+import java.io.File
+import java.io.IOException
+import java.util.*
+
+private const val PLAYER_DATA_FOLDER = "playerdata"
+private const val PLAYER_GAME_MODE_FILE = "playerGameType"
+
+private fun getPlayerFile(uuid: UUID): File? {
+    for (world in Bukkit.getWorlds()) {
+        val worldFolder = world.worldFolder
+        if (!worldFolder.isDirectory()) {
+            continue
+        }
+
+        val playerDataFolder = File(worldFolder, PLAYER_DATA_FOLDER)
+        if (!playerDataFolder.isDirectory()) {
+            continue
+        }
+
+        val playerFile = File(playerDataFolder, "$uuid.dat")
+        if (playerFile.exists()) {
+            return playerFile
+        }
+    }
+    return null
+}
+
+fun UUID.setOfflineLocation(location: Location) {
+    val dataFile: File = getPlayerFile(this) ?: return
+    val rawTag: CompoundBinaryTag
+    try {
+        rawTag = BinaryTagIO.unlimitedReader()
+            .read(dataFile.toPath(), GZIP)
+    } catch (e: IOException) {
+        error("Failed to read player data file for UUID $this: ${e.message}")
+    }
+
+    val builder = CompoundBinaryTag.builder().put(rawTag)
+    val posTag = ListBinaryTag.builder()
+    val rotTag = ListBinaryTag.builder()
+
+    posTag.add(DoubleBinaryTag.doubleBinaryTag(location.x))
+    posTag.add(DoubleBinaryTag.doubleBinaryTag(location.y))
+    posTag.add(DoubleBinaryTag.doubleBinaryTag(location.z))
+
+    rotTag.add(FloatBinaryTag.floatBinaryTag(location.yaw))
+    rotTag.add(FloatBinaryTag.floatBinaryTag(location.pitch))
+
+    builder.put("Pos", posTag.build())
+    builder.put("Rotation", rotTag.build())
+
+    val worldUUIDLeast: Long = location.getWorld().uid.leastSignificantBits
+    val worldUUIDMost: Long = location.getWorld().uid.mostSignificantBits
+
+    builder.putLong("WorldUUIDLeast", worldUUIDLeast)
+    builder.putLong("WorldUUIDMost", worldUUIDMost)
+
+    BinaryTagIO.writer()
+        .write(builder.build(), dataFile.toPath(), GZIP)
+}
+
+private fun setGameModeInFile(gameMode: GameMode, dataFile: File) {
+    val rawTag = BinaryTagIO.unlimitedReader().read(dataFile.toPath(), GZIP)
+    val builder = CompoundBinaryTag.builder().put(rawTag)
+
+    builder.put(PLAYER_GAME_MODE_FILE, IntBinaryTag.intBinaryTag(gameMode.value))
+
+    BinaryTagIO.writer().write(builder.build(), dataFile.toPath(), GZIP)
+}
+
+fun OfflinePlayer.setOfflineGameMode(gameMode: GameMode) {
+    val playerFile = getPlayerFile(this.uniqueId) ?: return
+
+    try {
+        setGameModeInFile(gameMode, playerFile)
+    } catch (e: IOException) {
+        error("Failed to set game mode for offline player ${this.name}: ${e.message}")
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/utils/offline-player-util.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/utils/offline-player-util.kt
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit
 import org.bukkit.GameMode
 import org.bukkit.Location
 import org.bukkit.OfflinePlayer
+import org.bukkit.entity.Player
 import java.io.File
 import java.io.IOException
 import java.util.*
@@ -33,6 +34,10 @@ private fun getPlayerFile(uuid: UUID): File? {
         }
     }
     return null
+}
+
+fun Player.setOfflineLocation(location: Location) {
+    this.uniqueId.setOfflineLocation(location)
 }
 
 fun UUID.setOfflineLocation(location: Location) {

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
@@ -1,7 +1,5 @@
 package dev.slne.surf.servertour.view
 
-import com.github.shynixn.mccoroutine.folia.launch
-import dev.slne.surf.servertour.plugin
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -37,8 +35,6 @@ class ViewListener : Listener {
     fun onDisconnect(event: PlayerQuitEvent) {
         val player = event.player
 
-        plugin.launch {
-            viewManager.quit(player)
-        }
+        viewManager.quitSync(player)
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
@@ -1,5 +1,7 @@
 package dev.slne.surf.servertour.view
 
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.servertour.plugin
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -35,6 +37,8 @@ class ViewListener : Listener {
     fun onDisconnect(event: PlayerQuitEvent) {
         val player = event.player
 
-        viewManager.quitSync(player)
+        plugin.launch {
+            viewManager.quitSync(player)
+        }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
@@ -25,6 +25,8 @@ class ViewListener : Listener {
         player.sendText {
             appendPrefix()
             error("Du kannst dich nicht bewegen, während du dir einen Eintrag ansiehst!")
+            appendSpace()
+            info("Solle ein Fehler auftreten, kannst du /servertour exitView benutzen.")
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
@@ -1,9 +1,12 @@
 package dev.slne.surf.servertour.view
 
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.servertour.plugin
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerQuitEvent
 
 class ViewListener : Listener {
     @EventHandler
@@ -26,7 +29,16 @@ class ViewListener : Listener {
             appendPrefix()
             error("Du kannst dich nicht bewegen, während du dir einen Eintrag ansiehst!")
             appendSpace()
-            info("Solle ein Fehler auftreten, kannst du /servertour exitView benutzen.")
+            info("Sollte ein Fehler auftreten, kannst du /servertour exitView benutzen.")
+        }
+    }
+
+    @EventHandler
+    fun onDisconnect(event: PlayerQuitEvent) {
+        val player = event.player
+
+        plugin.launch {
+            viewManager.quit(player)
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt
@@ -1,0 +1,30 @@
+package dev.slne.surf.servertour.view
+
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerMoveEvent
+
+class ViewListener : Listener {
+    @EventHandler
+    fun onMove(event: PlayerMoveEvent) {
+        if (!event.hasChangedBlock()) {
+            return
+        }
+
+        val player = event.player
+
+        if (!viewManager.currentPoIViews.contains(player.uniqueId) && !viewManager.currentTourViews.contains(
+                player.uniqueId
+            )
+        ) {
+            return
+        }
+
+        event.isCancelled = true
+        player.sendText {
+            appendPrefix()
+            error("Du kannst dich nicht bewegen, während du dir einen Eintrag ansiehst!")
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -64,8 +64,29 @@ class ViewManager {
         }
     }
 
-    suspend fun quit(player: Player) {
-        exitView(player)
+    fun quitSync(player: Player) {
+        if (currentPoIViews.containsKey(player.uniqueId)) {
+            val loc = previousLocations.remove(player.uniqueId)
+                ?: error("No previous location found for player ${player.name}")
+            currentPoIViews.remove(player.uniqueId)
+
+            player.gameMode = GameMode.SURVIVAL
+//            player.teleport(loc)
+            plugin.launch(plugin.regionDispatcher(loc)) {
+                player.teleport(loc)
+            }
+        } else if (currentTourViews.containsKey(player.uniqueId)) {
+            val loc = previousLocations.remove(player.uniqueId)
+                ?: error("No previous location found for player ${player.name}")
+            currentTourViews.remove(player.uniqueId)
+
+            player.gameMode = GameMode.SURVIVAL
+//            player.teleport(loc)
+
+            plugin.launch(plugin.regionDispatcher(loc)) {
+                player.teleport(loc)
+            }
+        }
     }
 
     suspend fun shutdown() {

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -66,7 +66,7 @@ class ViewManager {
         }
     }
 
-    fun quitSync(player: Player) {
+    suspend fun quitSync(player: Player) {
         if (currentPoIViews.containsKey(player.uniqueId)) {
             val loc = previousLocations.remove(player.uniqueId)
                 ?: error("No previous location found for player ${player.name}")

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -5,6 +5,8 @@ import com.github.shynixn.mccoroutine.folia.regionDispatcher
 import dev.slne.surf.servertour.entry.Poi
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
+import dev.slne.surf.servertour.utils.setOfflineGameMode
+import dev.slne.surf.servertour.utils.setOfflineLocation
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask
@@ -70,19 +72,15 @@ class ViewManager {
                 ?: error("No previous location found for player ${player.name}")
             currentPoIViews.remove(player.uniqueId)
 
-            player.gameMode = GameMode.SURVIVAL
-            plugin.launch(plugin.regionDispatcher(loc)) {
-                player.teleport(loc)
-            }
+            player.setOfflineGameMode(GameMode.SURVIVAL)
+            player.setOfflineLocation(loc)
         } else if (currentTourViews.containsKey(player.uniqueId)) {
             val loc = previousLocations.remove(player.uniqueId)
                 ?: error("No previous location found for player ${player.name}")
             currentTourViews.remove(player.uniqueId)
 
-            player.gameMode = GameMode.SURVIVAL
-            plugin.launch(plugin.regionDispatcher(loc)) {
-                player.teleport(loc)
-            }
+            player.setOfflineGameMode(GameMode.SURVIVAL)
+            player.setOfflineLocation(loc)
         }
     }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -23,6 +23,8 @@ class ViewManager {
     val currentPoIViews = mutableObject2ObjectMapOf<UUID, Pair<Poi, Long>>()
     val previousLocations = mutableObject2ObjectMapOf<UUID, Location>()
 
+    val viewTimeout = TimeUnit.SECONDS.toMillis(5L)
+
     lateinit var task: ScheduledTask
 
     suspend fun viewPoi(player: Player, poi: Poi) =
@@ -116,7 +118,7 @@ class ViewManager {
 
             currentTourViews.entries.toList().forEach { (uuid, pair) ->
                 val player = plugin.server.getPlayer(uuid) ?: return@forEach
-                val remaining = (pair.second + TimeUnit.SECONDS.toMillis(5) - now) / 1000
+                val remaining = (pair.second + viewTimeout - now) / 1000
 
                 if (remaining <= 0) {
                     plugin.launch {
@@ -133,7 +135,7 @@ class ViewManager {
 
             currentPoIViews.entries.toList().forEach { (uuid, pair) ->
                 val player = plugin.server.getPlayer(uuid) ?: return@forEach
-                val remaining = (pair.second + TimeUnit.SECONDS.toMillis(5) - now) / 1000
+                val remaining = (pair.second + viewTimeout - now) / 1000
 
                 if (remaining <= 0) {
                     plugin.launch {

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.servertour.plugin
 import dev.slne.surf.servertour.utils.setOfflineGameMode
 import dev.slne.surf.servertour.utils.setOfflineLocation
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask
 import kotlinx.coroutines.withContext
@@ -30,6 +31,14 @@ class ViewManager {
 
     suspend fun viewPoi(player: Player, poi: Poi) =
         withContext(plugin.regionDispatcher(poi.location)) {
+            if (currentPoIViews.containsKey(player.uniqueId)) {
+                player.sendText {
+                    appendPrefix()
+                    error("Du betrachtest bereits einen anderen Punkt.")
+                }
+                return@withContext
+            }
+
             currentPoIViews[player.uniqueId] = poi to System.currentTimeMillis()
             previousLocations[player.uniqueId] = player.location
             previousGameModes[player.uniqueId] = player.gameMode
@@ -40,6 +49,14 @@ class ViewManager {
 
     suspend fun viewTour(player: Player, entry: TourEntry) =
         withContext(plugin.regionDispatcher(entry.location)) {
+            if (currentTourViews.containsKey(player.uniqueId)) {
+                player.sendText {
+                    appendPrefix()
+                    error("Du betrachtest bereits eine andere Tour.")
+                }
+                return@withContext
+            }
+
             currentTourViews[player.uniqueId] = entry to System.currentTimeMillis()
             previousLocations[player.uniqueId] = player.location
             previousGameModes[player.uniqueId] = player.gameMode

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -64,6 +64,10 @@ class ViewManager {
         }
     }
 
+    suspend fun quit(player: Player) {
+        exitView(player)
+    }
+
     suspend fun shutdown() {
         currentPoIViews.keys.forEach { uuid ->
             val player = plugin.server.getPlayer(uuid) ?: return@forEach

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -1,0 +1,121 @@
+package dev.slne.surf.servertour.view
+
+import com.github.shynixn.mccoroutine.folia.launch
+import com.github.shynixn.mccoroutine.folia.regionDispatcher
+import dev.slne.surf.servertour.entry.Poi
+import dev.slne.surf.servertour.entry.TourEntry
+import dev.slne.surf.servertour.plugin
+import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask
+import kotlinx.coroutines.withContext
+import org.bukkit.Bukkit
+import org.bukkit.GameMode
+import org.bukkit.Location
+import org.bukkit.entity.Player
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+class ViewManager {
+    val currentTourViews = mutableObject2ObjectMapOf<UUID, Pair<TourEntry, Long>>()
+    val currentPoIViews = mutableObject2ObjectMapOf<UUID, Pair<Poi, Long>>()
+    val previousLocations = mutableObject2ObjectMapOf<UUID, Location>()
+
+    lateinit var task: ScheduledTask
+
+    suspend fun viewPoi(player: Player, poi: Poi) =
+        withContext(plugin.regionDispatcher(poi.location)) {
+            currentPoIViews[player.uniqueId] = poi to System.currentTimeMillis()
+            previousLocations[player.uniqueId] = player.location
+
+            player.gameMode = GameMode.SPECTATOR
+            player.teleportAsync(poi.location)
+        }
+
+    suspend fun viewTour(player: Player, entry: TourEntry) =
+        withContext(plugin.regionDispatcher(entry.location)) {
+            currentTourViews[player.uniqueId] = entry to System.currentTimeMillis()
+            previousLocations[player.uniqueId] = player.location
+
+            player.gameMode = GameMode.SPECTATOR
+            player.teleportAsync(entry.location)
+        }
+
+
+    suspend fun exitViewPoi(player: Player) {
+        val loc = previousLocations.remove(player.uniqueId)
+            ?: error("No previous location found for player ${player.name}")
+        currentPoIViews.remove(player.uniqueId)
+
+        withContext(plugin.regionDispatcher(loc)) {
+            player.teleportAsync(loc)
+            player.gameMode = GameMode.SURVIVAL
+        }
+    }
+
+    suspend fun exitViewTour(player: Player) {
+        val loc = previousLocations.remove(player.uniqueId)
+            ?: error("No previous location found for player ${player.name}")
+        currentTourViews.remove(player.uniqueId)
+
+        withContext(plugin.regionDispatcher(loc)) {
+            player.teleportAsync(loc)
+            player.gameMode = GameMode.SURVIVAL
+        }
+    }
+
+    suspend fun shutdown() {
+        currentPoIViews.keys.forEach { uuid ->
+            val player = plugin.server.getPlayer(uuid) ?: return@forEach
+            exitViewPoi(player)
+        }
+
+        currentTourViews.keys.forEach { uuid ->
+            val player = plugin.server.getPlayer(uuid) ?: return@forEach
+            exitViewTour(player)
+        }
+    }
+
+    suspend fun exitView(player: Player): Boolean {
+        if (currentPoIViews.containsKey(player.uniqueId)) {
+            exitViewPoi(player)
+            return true
+        } else if (currentTourViews.containsKey(player.uniqueId)) {
+            exitViewTour(player)
+            return true
+        }
+
+        return false
+    }
+
+    suspend fun startTask() {
+        task = Bukkit.getAsyncScheduler().runAtFixedRate(plugin, {
+            val now = System.currentTimeMillis()
+
+            currentTourViews.entries.toList().forEach { (uuid, pair) ->
+                if (pair.second <= now - TimeUnit.SECONDS.toMillis(5)) {
+                    val player = plugin.server.getPlayer(uuid) ?: return@forEach
+                    plugin.launch {
+                        exitViewTour(player)
+                    }
+                }
+            }
+
+            currentPoIViews.entries.toList().forEach { (uuid, pair) ->
+                if (pair.second <= now - TimeUnit.SECONDS.toMillis(5)) {
+                    val player = plugin.server.getPlayer(uuid) ?: return@forEach
+                    plugin.launch {
+                        exitViewPoi(player)
+                    }
+                }
+            }
+
+        }, 0L, 1L, TimeUnit.SECONDS)
+    }
+
+
+    companion object {
+        val INSTANCE = ViewManager()
+    }
+}
+
+val viewManager get() = ViewManager.INSTANCE

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -93,17 +93,20 @@ class ViewManager {
     }
 
     suspend fun quitSync(player: Player) {
-        val previousGameMode = previousGameModes.remove(player.uniqueId)
-            ?: error("No previous game mode found for player ${player.name}")
-        val loc = previousLocations.remove(player.uniqueId)
-            ?: error("No previous location found for player ${player.name}")
-
         if (currentPoIViews.containsKey(player.uniqueId)) {
+            val previousGameMode = previousGameModes.remove(player.uniqueId)
+                ?: error("No previous game mode found for player ${player.name}")
+            val loc = previousLocations.remove(player.uniqueId)
+                ?: error("No previous location found for player ${player.name}")
             currentPoIViews.remove(player.uniqueId)
 
             player.setOfflineGameMode(previousGameMode)
             player.setOfflineLocation(loc)
         } else if (currentTourViews.containsKey(player.uniqueId)) {
+            val previousGameMode = previousGameModes.remove(player.uniqueId)
+                ?: error("No previous game mode found for player ${player.name}")
+            val loc = previousLocations.remove(player.uniqueId)
+                ?: error("No previous location found for player ${player.name}")
             currentTourViews.remove(player.uniqueId)
 
             player.setOfflineGameMode(previousGameMode)

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -97,7 +97,9 @@ class ViewManager {
             exitViewTour(player)
         }
 
-        task.cancel()
+        if (::task.isInitialized) {
+            task.cancel()
+        }
     }
 
     suspend fun exitView(player: Player): Boolean {

--- a/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt
@@ -71,7 +71,6 @@ class ViewManager {
             currentPoIViews.remove(player.uniqueId)
 
             player.gameMode = GameMode.SURVIVAL
-//            player.teleport(loc)
             plugin.launch(plugin.regionDispatcher(loc)) {
                 player.teleport(loc)
             }
@@ -81,8 +80,6 @@ class ViewManager {
             currentTourViews.remove(player.uniqueId)
 
             player.gameMode = GameMode.SURVIVAL
-//            player.teleport(loc)
-
             plugin.launch(plugin.regionDispatcher(loc)) {
                 player.teleport(loc)
             }


### PR DESCRIPTION
This pull request introduces a major new feature: a "view mode" for tours and points of interest (PoIs), allowing players to spectate their own entries or PoIs for a limited time. It includes the implementation of the `ViewManager`, new dialog actions and commands to enter and exit view mode, and supporting utilities for managing player state. Additionally, it improves dialog information and makes minor version and code style updates.

**New View Mode Feature**

* Added `ViewManager` and `ViewListener` to handle spectating logic, including teleporting players, setting their game mode, preventing movement during view mode, handling disconnects, and automatically returning them after 5 seconds. (`src/main/kotlin/dev/slne/surf/servertour/view/ViewManager.kt` [[1]](diffhunk://#diff-3e7396e302932eb051c0cff0120aabfe59664649fe21df070d61e5bc68e1820aR1-R172) `src/main/kotlin/dev/slne/surf/servertour/view/ViewListener.kt` [[2]](diffhunk://#diff-07f9a9fa7bed936285e76746089bb2580f68a4a7367ec807209fe3949243636dR1-R44)
* Integrated `viewManager` into the plugin lifecycle: starts on enable, shuts down on disable, and registers event listeners. (`src/main/kotlin/dev/slne/surf/servertour/SurfServerTour.kt` [[1]](diffhunk://#diff-08504f4a00dd29602f407f72c1e25cd00e39ff887eb03f21560b9510f34aa78cR9-R11) [[2]](diffhunk://#diff-08504f4a00dd29602f407f72c1e25cd00e39ff887eb03f21560b9510f34aa78cR42-L44)
* Added new `/servertour exitView` subcommand to allow players to manually exit view mode if needed. (`src/main/kotlin/dev/slne/surf/servertour/commands/ServerTourViewExitCommand.kt` [[1]](diffhunk://#diff-67c225a4ee334c33d2ea2ef2234176ba21cdf236b7d9b3144afb7fee7cbdef5bR1-R30) `src/main/kotlin/dev/slne/surf/servertour/commands/ServerTourCommand.kt` [[2]](diffhunk://#diff-5ca352b8f58694359c45e4b46ac5475670026104038279ab3ea57e4b4a07070dR11-R12)

**Dialog and UI Improvements**

* Added "Tour ansehen" and "PoI Ansehen" buttons to entry and PoI dialogs, allowing players to enter view mode directly from the UI. (`src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt` [[1]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250R125-R145) [[2]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250L88-R92) [[3]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250R17-R23); `src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt` [[4]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49L53-R72) [[5]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49R91-R114) [[6]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49R12-R18)
* Dialogs now show additional PoI location information and use `NONE` for `afterAction` to prevent auto-closing dialogs while in view mode. (`src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt` [[1]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49R36-R50) [[2]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49L53-R72); `src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt` [[3]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250L88-R92)

**Player State Utility**

* Added utility functions to safely set offline player location and game mode in NBT files, supporting safe restoration after view mode or disconnect. (`src/main/kotlin/dev/slne/surf/servertour/utils/offline-player-util.kt` [src/main/kotlin/dev/slne/surf/servertour/utils/offline-player-util.ktR1-R98](diffhunk://#diff-df3ef689c5becd49249935b491920c7cc1bae2d6f88419fbfa4c2c245043b8eeR1-R98))

**Other Improvements**

* Opted in to `NmsUseWithCaution` in relevant files for NMS usage. (`src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt` [[1]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250R2) [[2]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250R17-R23); `src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt` [[3]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49R2) [[4]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49R12-R18)
* Bumped project version to `1.21.7-1.0.1-SNAPSHOT`. (`gradle.properties` [gradle.propertiesL4-R4](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L4-R4))