### PR TITLE
Feat/review phase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.0.1-SNAPSHOT
+version=1.21.7-1.0.2-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -25,7 +25,7 @@ fun serverTourDialog(owner: UUID) = dialog {
 
     type {
         multiAction {
-            columns(2)
+            columns(1)
 
             action(listOwnTours(owner))
             action(createOwnTourButton())
@@ -42,7 +42,7 @@ fun serverTourDialog(owner: UUID) = dialog {
 }
 
 private fun createOwnTourButton(): ActionButton = actionButton {
-    label { text("Einreichung erstellen") }
+    label { info("Einreichung erstellen") }
     tooltip { info("Erstellt eine neue Einreichung") }
 
     action {
@@ -65,7 +65,7 @@ private fun listOwnTours(owner: UUID): ActionButton = actionButton {
 }
 
 private fun createShowcaseTourButton(): ActionButton = actionButton {
-    label { variableValue("Einreichungen ansehen") }
+    label { variableValue("Server Tour") }
     tooltip { info("Sieh dir alle Einreichungen an") }
 
     action {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -5,7 +5,9 @@ package dev.slne.surf.servertour.dialogs
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.servertour.dialogs.own.createOwnTourDialog
 import dev.slne.surf.servertour.dialogs.own.review.showcase.createShowcaseTourDialog
+import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTourDialog
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createViewSubmittedToursDialog
+import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
 import dev.slne.surf.servertour.utils.ServerTourPermissionRegistry
 import dev.slne.surf.servertour.utils.hasPermission
@@ -13,10 +15,12 @@ import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
-import io.papermc.paper.dialog.Dialog
+import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import io.papermc.paper.registry.data.dialog.ActionButton
 import io.papermc.paper.registry.data.dialog.DialogBase
 import java.util.*
+
+val SERVER_TOUR_LAST_VIEWED = mutableObject2ObjectMapOf<UUID, TourEntry>()
 
 fun serverTourDialog(owner: UUID) = dialog {
     base {
@@ -38,6 +42,10 @@ fun serverTourDialog(owner: UUID) = dialog {
             if (owner.hasPermission(ServerTourPermissionRegistry.SHOWCASE)) {
                 action(createShowcaseTourButton())
             }
+
+            SERVER_TOUR_LAST_VIEWED[owner]?.let {
+                action(createResumeTourButton(it))
+            }
         }
     }
 }
@@ -53,13 +61,13 @@ private fun createOwnTourButton(): ActionButton = actionButton {
     }
 }
 
-private fun createResumeTourButton(dialog: Dialog) = actionButton {
-    label { info("Server Tour fortsetzen") }
+private fun createResumeTourButton(entry: TourEntry) = actionButton {
+    label { success("Server Tour fortsetzen") }
     tooltip { info("Startet bei deiner letzten Ansicht") }
 
     action {
         playerCallback { player ->
-            player.showDialog(dialog)
+            player.showDialog(createSubmittedTourDialog(entry, true))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -4,6 +4,7 @@ package dev.slne.surf.servertour.dialogs
 
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.servertour.dialogs.own.createOwnTourDialog
+import dev.slne.surf.servertour.dialogs.own.review.showcase.createShowcaseTourDialog
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createViewSubmittedToursDialog
 import dev.slne.surf.servertour.plugin
 import dev.slne.surf.servertour.utils.ServerTourPermissionRegistry
@@ -29,8 +30,12 @@ fun serverTourDialog(owner: UUID) = dialog {
             action(listOwnTours(owner))
             action(createOwnTourButton())
 
-            if(owner.hasPermission(ServerTourPermissionRegistry.REVIEWER)) {
+            if (owner.hasPermission(ServerTourPermissionRegistry.REVIEWER)) {
                 action(createViewSubmittedToursButton())
+            }
+
+            if (owner.hasPermission(ServerTourPermissionRegistry.SHOWCASE)) {
+                action(createShowcaseTourButton())
             }
         }
     }
@@ -48,7 +53,7 @@ private fun createOwnTourButton(): ActionButton = actionButton {
 }
 
 private fun listOwnTours(owner: UUID): ActionButton = actionButton {
-    label { text("Eigene Einreichungen") }
+    label { info("Eigene Einreichungen") }
 
     action {
         playerCallback {
@@ -59,9 +64,22 @@ private fun listOwnTours(owner: UUID): ActionButton = actionButton {
     }
 }
 
+private fun createShowcaseTourButton(): ActionButton = actionButton {
+    label { variableValue("Einreichungen ansehen") }
+    tooltip { info("Sieh dir alle Einreichungen an") }
+
+    action {
+        playerCallback { player ->
+            plugin.launch {
+                player.showDialog(createShowcaseTourDialog())
+            }
+        }
+    }
+}
+
 private fun createViewSubmittedToursButton(): ActionButton = actionButton {
-    label { text("Einreichungen ansehen") }
-    tooltip { info("Sieh dir alle Einreichungen an, die auf eine Überprüfung warten") }
+    label { variableValue("Einreichungen ansehen") }
+    tooltip { info("Sieh dir alle Einreichungen an, welche auf eine Überprüfung warten") }
 
     action {
         playerCallback { player ->

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -92,7 +92,9 @@ private fun createShowcaseTourButton(): ActionButton = actionButton {
     action {
         playerCallback { player ->
             plugin.launch {
-                player.showDialog(createShowcaseTourDialog())
+                val dialog = createShowcaseTourDialog()
+                player.showDialog(dialog)
+                SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = dialog
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -85,7 +85,7 @@ private fun listOwnTours(owner: UUID): ActionButton = actionButton {
 }
 
 private fun createShowcaseTourButton(): ActionButton = actionButton {
-    label { variableValue("Server Tour") }
+    label { variableValue("Server Tour starten") }
     tooltip { info("Sieh dir alle Einreichungen an") }
 
     action {
@@ -98,7 +98,7 @@ private fun createShowcaseTourButton(): ActionButton = actionButton {
 }
 
 private fun createViewSubmittedToursButton(): ActionButton = actionButton {
-    label { variableValue("Einreichungen ansehen") }
+    label { variableValue("Einreichungen auswerten") }
     tooltip { info("Sieh dir alle Einreichungen an, welche auf eine Überprüfung warten") }
 
     action {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -4,7 +4,10 @@ package dev.slne.surf.servertour.dialogs
 
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.servertour.dialogs.own.createOwnTourDialog
+import dev.slne.surf.servertour.dialogs.own.review.submitted.createViewSubmittedToursDialog
 import dev.slne.surf.servertour.plugin
+import dev.slne.surf.servertour.utils.ServerTourPermissionRegistry
+import dev.slne.surf.servertour.utils.hasPermission
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
@@ -21,10 +24,14 @@ fun serverTourDialog(owner: UUID) = dialog {
 
     type {
         multiAction {
-            columns(1)
+            columns(2)
 
             action(listOwnTours(owner))
             action(createOwnTourButton())
+
+            if(owner.hasPermission(ServerTourPermissionRegistry.REVIEWER)) {
+                action(createViewSubmittedToursButton())
+            }
         }
     }
 }
@@ -47,6 +54,19 @@ private fun listOwnTours(owner: UUID): ActionButton = actionButton {
         playerCallback {
             plugin.launch {
                 it.showDialog(listOwnToursDialog(owner))
+            }
+        }
+    }
+}
+
+private fun createViewSubmittedToursButton(): ActionButton = actionButton {
+    label { text("Einreichungen ansehen") }
+    tooltip { info("Sieh dir alle Einreichungen an, die auf eine Überprüfung warten") }
+
+    action {
+        playerCallback { player ->
+            plugin.launch {
+                player.showDialog(createViewSubmittedToursDialog())
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -13,9 +13,13 @@ import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
+import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.ActionButton
 import io.papermc.paper.registry.data.dialog.DialogBase
 import java.util.*
+
+val SERVER_TOUR_LATEST_DIALOGS = mutableObject2ObjectMapOf<UUID, Dialog>()
 
 fun serverTourDialog(owner: UUID) = dialog {
     base {
@@ -37,6 +41,12 @@ fun serverTourDialog(owner: UUID) = dialog {
             if (owner.hasPermission(ServerTourPermissionRegistry.SHOWCASE)) {
                 action(createShowcaseTourButton())
             }
+
+            val last = SERVER_TOUR_LATEST_DIALOGS[owner]
+
+            if (last != null) {
+                action(createResumeTourButton(last))
+            }
         }
     }
 }
@@ -48,6 +58,17 @@ private fun createOwnTourButton(): ActionButton = actionButton {
     action {
         playerCallback { player ->
             player.showDialog(createOwnTourDialog())
+        }
+    }
+}
+
+private fun createResumeTourButton(dialog: Dialog) = actionButton {
+    label { info("Server Tour fortsetzen") }
+    tooltip { info("Startet bei deiner letzten Ansicht") }
+
+    action {
+        playerCallback { player ->
+            player.showDialog(dialog)
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -29,7 +29,7 @@ fun serverTourDialog(owner: UUID) = dialog {
 
     type {
         multiAction {
-            columns(1)
+            columns(2)
 
             action(listOwnTours(owner))
             action(createOwnTourButton())

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -13,13 +13,10 @@ import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
-import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.ActionButton
 import io.papermc.paper.registry.data.dialog.DialogBase
 import java.util.*
-
-val SERVER_TOUR_LATEST_DIALOGS = mutableObject2ObjectMapOf<UUID, Dialog>()
 
 fun serverTourDialog(owner: UUID) = dialog {
     base {
@@ -40,12 +37,6 @@ fun serverTourDialog(owner: UUID) = dialog {
 
             if (owner.hasPermission(ServerTourPermissionRegistry.SHOWCASE)) {
                 action(createShowcaseTourButton())
-            }
-
-            val last = SERVER_TOUR_LATEST_DIALOGS[owner]
-
-            if (last != null) {
-                action(createResumeTourButton(last))
             }
         }
     }
@@ -92,9 +83,7 @@ private fun createShowcaseTourButton(): ActionButton = actionButton {
     action {
         playerCallback { player ->
             plugin.launch {
-                val dialog = createShowcaseTourDialog()
-                player.showDialog(dialog)
-                SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = dialog
+                player.showDialog(createShowcaseTourDialog())
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
@@ -24,7 +24,7 @@ import io.papermc.paper.registry.data.dialog.DialogBase
 import net.kyori.adventure.text.Component
 
 fun buildOwnTourTitle(entry: TourEntry, vararg subs: Component) = buildText {
-    primary("Eigene Einreichungen")
+    primary("Einreichungen")
     spacer(" - ")
     append(entry)
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
@@ -24,7 +24,7 @@ import io.papermc.paper.registry.data.dialog.DialogBase
 import net.kyori.adventure.text.Component
 
 fun buildOwnTourTitle(entry: TourEntry, vararg subs: Component) = buildText {
-    primary("Einreichungen")
+    primary("Eigene Einreichungen")
     spacer(" - ")
     append(entry)
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
@@ -7,9 +7,9 @@ import dev.slne.surf.servertour.dialogs.listOwnToursDialog
 import dev.slne.surf.servertour.dialogs.own.information.descriptionOwnTourEntryDialog
 import dev.slne.surf.servertour.dialogs.own.information.renameOwnTourEntryDialog
 import dev.slne.surf.servertour.dialogs.own.member.addMemberToOwnTourDialog
-import dev.slne.surf.servertour.dialogs.own.member.ownTourMembersDialog
+import dev.slne.surf.servertour.dialogs.own.member.createTourMembersDialog
 import dev.slne.surf.servertour.dialogs.own.poi.createPoiDialog
-import dev.slne.surf.servertour.dialogs.own.poi.ownTourPoisDialog
+import dev.slne.surf.servertour.dialogs.own.poi.createTourPoIsDialog
 import dev.slne.surf.servertour.entry.EntryManager
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
@@ -207,7 +207,7 @@ private fun listPoisButton(entry: TourEntry, editable: Boolean) = actionButton {
     tooltip { info("Zeige die POIs der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(ownTourPoisDialog(entry, editable)) }
+        playerCallback { it.showDialog(createTourPoIsDialog(entry, editable)) }
     }
 }
 
@@ -225,7 +225,7 @@ private fun listMembersButton(entry: TourEntry, editable: Boolean) = actionButto
     tooltip { info("Zeige die Mitglieder der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(ownTourMembersDialog(entry, editable)) }
+        playerCallback { it.showDialog(createTourMembersDialog(entry, editable)) }
     }
 }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/OwnTourDialog.kt
@@ -62,7 +62,7 @@ fun buildTourBody(entry: TourEntry) = buildText {
     variableValue("(${pois.size})")
     appendNewline()
     if (pois.isNotEmpty()) {
-        variableValue(pois.joinToString(", ") { it.name })
+        variableValue(pois.sortedBy { it.name }.joinToString(", ") { it.name })
     } else {
         variableValue("Keine POIs vorhanden")
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/member/OneMemberDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/member/OneMemberDialog.kt
@@ -66,7 +66,7 @@ private fun backButton(entry: TourEntry, editable: Boolean) = actionButton {
     tooltip { info("Zurück zu den Mitgliedern") }
 
     action {
-        playerCallback { it.showDialog(ownTourMembersDialog(entry, editable)) }
+        playerCallback { it.showDialog(createTourMembersDialog(entry, editable)) }
     }
 }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/member/OwnMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/member/OwnMembersDialog.kt
@@ -13,7 +13,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
 
-fun ownTourMembersDialog(entry: TourEntry, editable: Boolean): Dialog = dialog {
+fun createTourMembersDialog(entry: TourEntry, editable: Boolean): Dialog = dialog {
     val members = buildDialogList(entry, editable)
 
     base {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/member/RemoveMemberDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/member/RemoveMemberDialog.kt
@@ -60,7 +60,7 @@ private fun backButton(
 
     action {
         playerCallback { player ->
-            player.showDialog(ownTourMembersDialog(entry, editable))
+            player.showDialog(createTourMembersDialog(entry, editable))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OnePoiDialog.kt
@@ -83,7 +83,7 @@ private fun backButton(entry: TourEntry, editable: Boolean) = actionButton {
     tooltip { info("Zurück zu den POIs") }
 
     action {
-        playerCallback { it.showDialog(ownTourPoisDialog(entry, editable)) }
+        playerCallback { it.showDialog(createTourPoIsDialog(entry, editable)) }
     }
 }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OwnPoisDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/OwnPoisDialog.kt
@@ -13,7 +13,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
 
-fun ownTourPoisDialog(entry: TourEntry, editable: Boolean): Dialog = dialog {
+fun createTourPoIsDialog(entry: TourEntry, editable: Boolean): Dialog = dialog {
     val dialogs = buildDialogList(entry, editable).sortedBy { it.first.name }
 
     base {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/RemovePoiDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/poi/RemovePoiDialog.kt
@@ -57,7 +57,7 @@ private fun backButton(entry: TourEntry, editable: Boolean): ActionButton = acti
 
     action {
         playerCallback {
-            it.showDialog(ownTourPoisDialog(entry, editable))
+            it.showDialog(createTourPoIsDialog(entry, editable))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -2,7 +2,6 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.showcase
 
-import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTourDialog
 import dev.slne.surf.servertour.dialogs.serverTourDialog
 import dev.slne.surf.servertour.entry.EntryManager
@@ -62,7 +61,6 @@ suspend fun createShowcaseTourDialog(): Dialog {
                             action {
                                 playerCallback { player ->
                                     player.showDialog(it.second)
-                                    SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = it.second
                                 }
                             }
                         }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -2,6 +2,7 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.showcase
 
+import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTourDialog
 import dev.slne.surf.servertour.dialogs.serverTourDialog
 import dev.slne.surf.servertour.entry.EntryManager
@@ -61,6 +62,7 @@ suspend fun createShowcaseTourDialog(): Dialog {
                             action {
                                 playerCallback { player ->
                                     player.showDialog(it.second)
+                                    SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = it.second
                                 }
                             }
                         }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -2,6 +2,7 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.showcase
 
+import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LAST_VIEWED
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTourDialog
 import dev.slne.surf.servertour.dialogs.serverTourDialog
 import dev.slne.surf.servertour.entry.EntryManager
@@ -61,6 +62,7 @@ suspend fun createShowcaseTourDialog(): Dialog {
                             action {
                                 playerCallback { player ->
                                     player.showDialog(it.second)
+                                    SERVER_TOUR_LAST_VIEWED[player.uniqueId] = it.first
                                 }
                             }
                         }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -1,0 +1,83 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.showcase
+
+import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTourDialog
+import dev.slne.surf.servertour.dialogs.serverTourDialog
+import dev.slne.surf.servertour.entry.EntryManager
+import dev.slne.surf.servertour.entry.EntryStatus
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.util.toObjectList
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+suspend fun createShowcaseTourDialog(): Dialog {
+    val acceptedTours = EntryManager.listEntries()
+        .filter { it.status == EntryStatus.ACCEPTED }
+        .sortedBy {
+            it.name
+        }
+        .map {
+            it to createSubmittedTourDialog(it, true)
+        }
+        .toObjectList()
+    return dialog {
+        base {
+            title { primary("Einreichungen") }
+            afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+
+            if (acceptedTours.isEmpty()) {
+                body {
+                    plainMessage(400) {
+                        error("Es wurden keine Einreichungen gefunden")
+                    }
+                }
+            }
+        }
+
+        type {
+            if (acceptedTours.isEmpty()) {
+                notice {
+                    label { error("Zurück") }
+                    tooltip { info("Zurück zum Hauptmenü") }
+
+                    action {
+                        playerCallback {
+                            it.showDialog(serverTourDialog(it.uniqueId))
+                        }
+                    }
+                }
+            } else {
+                multiAction {
+                    columns(3)
+
+                    acceptedTours.forEach {
+                        action {
+                            label { variableKey(it.first.name) }
+                            tooltip { info("Einreichung ansehen: ${it.first.name}") }
+
+                            action {
+                                playerCallback { player ->
+                                    player.showDialog(it.second)
+                                }
+                            }
+                        }
+                    }
+
+                    exitAction {
+                        label { error("Zurück") }
+                        tooltip { info("Zurück zum Hauptmenü") }
+
+                        action {
+                            playerCallback {
+                                it.showDialog(serverTourDialog(it.uniqueId))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -3,8 +3,6 @@
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
 import com.github.shynixn.mccoroutine.folia.launch
-import dev.slne.surf.servertour.dialogs.own.member.createTourMembersDialog
-import dev.slne.surf.servertour.dialogs.own.poi.createTourPoIsDialog
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
@@ -59,7 +57,7 @@ private fun listMembersButton(entry: TourEntry) = actionButton {
     tooltip { info("Zeige die Mitglieder der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(createTourMembersDialog(entry, false)) }
+        playerCallback { it.showDialog(createSubmittedTourMembersDialog(entry)) }
     }
 }
 
@@ -68,7 +66,7 @@ private fun listPoIsButton(entry: TourEntry) = actionButton {
     tooltip { info("Zeige die POIs der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(createTourPoIsDialog(entry, false)) }
+        playerCallback { it.showDialog(createSubmittedTourPoIsDialog(entry)) }
     }
 }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -182,7 +182,7 @@ fun buildTourBody(entry: TourEntry) = buildText {
     appendNewline(2)
 
     val poIs = entry.poi
-    variableKey("POIs ")
+    variableKey("POIs:")
     variableValue("(${poIs.size})")
     appendNewline()
     if (poIs.isNotEmpty()) {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -1,4 +1,5 @@
 @file:Suppress("UnstableApiUsage")
+@file:OptIn(NmsUseWithCaution::class)
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
@@ -8,8 +9,10 @@ import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.clearDialogs
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.registry.data.dialog.DialogBase
@@ -41,6 +44,8 @@ fun createSubmittedTourDialog(entry: TourEntry, showcase: Boolean = false) = dia
                 action(acceptButton(entry))
                 action(declineButton(entry))
             }
+
+            action(teleportButton(entry))
         }
     }
 }
@@ -54,6 +59,18 @@ private fun backButton(showcase: Boolean) = actionButton {
             plugin.launch {
                 it.showDialog(if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog())
             }
+        }
+    }
+}
+
+private fun teleportButton(entry: TourEntry) = actionButton {
+    label { info("Teleportieren") }
+    tooltip { info("Teleportiere dich zu dieser Tour") }
+
+    action {
+        playerCallback { player ->
+            player.teleportAsync(entry.location)
+            player.clearDialogs()
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -64,7 +64,7 @@ private fun acceptButton(entry: TourEntry) = actionButton {
             plugin.launch {
                 entry.accept()
             }
-            it.showDialog(createSubmittedTourMembersDialog(entry))
+            it.showDialog(createEntryUpdatedNotice(true))
         }
     }
 }
@@ -78,7 +78,39 @@ private fun declineButton(entry: TourEntry) = actionButton {
             plugin.launch {
                 entry.reject()
             }
-            it.showDialog(createSubmittedTourMembersDialog(entry))
+            it.showDialog(createEntryUpdatedNotice(false))
+        }
+    }
+}
+
+private fun createEntryUpdatedNotice(accepted: Boolean) = dialog {
+    base {
+        title { primary("Erfolgreich") }
+        afterAction(DialogBase.DialogAfterAction.NONE)
+
+        body {
+            plainMessage(400) {
+                if (accepted) {
+                    success("Die Einreichung wurde angenommen.")
+                } else {
+                    error("Die Einreichung wurde abgelehnt.")
+                }
+            }
+        }
+
+        type {
+            notice {
+                action {
+                    label { text("Zurück") }
+                    tooltip { info("Zurück zu dne Einreichungen") }
+
+                    playerCallback {
+                        plugin.launch {
+                            it.showDialog(createViewSubmittedToursDialog())
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -1,0 +1,113 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.submitted
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.servertour.dialogs.own.member.createTourMembersDialog
+import dev.slne.surf.servertour.dialogs.own.poi.createTourPoIsDialog
+import dev.slne.surf.servertour.entry.TourEntry
+import dev.slne.surf.servertour.plugin
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+fun createSubmittedTourDialog(entry: TourEntry) = dialog {
+    base {
+        title {
+            primary("Tourübersicht für ")
+            variableValue(entry.name)
+        }
+        afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+
+        body {
+            plainMessage(400) {
+                append(buildTourBody(entry))
+            }
+        }
+    }
+
+    type {
+        multiAction {
+            columns(2)
+            exitAction(backButton())
+
+            action(listMembersButton(entry))
+            action(listPoIsButton(entry))
+        }
+    }
+}
+
+private fun backButton() = actionButton {
+    label { text("Zurück") }
+    tooltip { info("Zurück zu den Einreichungen") }
+
+    action {
+        playerCallback {
+            plugin.launch {
+                it.showDialog(createViewSubmittedToursDialog())
+            }
+        }
+    }
+}
+
+private fun listMembersButton(entry: TourEntry) = actionButton {
+    label { text("Mitglieder") }
+    tooltip { info("Zeige die Mitglieder der Einreichung an") }
+
+    action {
+        playerCallback { it.showDialog(createTourMembersDialog(entry, false)) }
+    }
+}
+
+private fun listPoIsButton(entry: TourEntry) = actionButton {
+    label { text("POIs") }
+    tooltip { info("Zeige die POIs der Einreichung an") }
+
+    action {
+        playerCallback { it.showDialog(createTourPoIsDialog(entry, false)) }
+    }
+}
+
+fun buildTourBody(entry: TourEntry) = buildText {
+    variableKey("Ersteller: ")
+    val offlineOwner = entry.owner.offlinePlayer
+    if (offlineOwner.hasPlayedBefore()) {
+        variableValue(offlineOwner.name ?: "Unbekannt")
+    } else {
+        variableValue("Unbekannt")
+    }
+    appendNewline(2)
+
+    val members = entry.members
+    variableKey("Mitglieder ")
+    variableValue("(${members.size})")
+    appendNewline()
+    if (members.isNotEmpty()) {
+        members.joinToString(", ") {
+            it.offlinePlayer.name ?: it.offlinePlayer.uniqueId.toString()
+        }.let { variableValue(it) }
+    } else {
+        variableValue("Keine Mitglieder vorhanden")
+    }
+    appendNewline(2)
+
+    val pois = entry.poi
+    variableKey("POIs ")
+    variableValue("(${pois.size})")
+    appendNewline()
+    if (pois.isNotEmpty()) {
+        variableValue(pois.joinToString(", ") { it.name })
+    } else {
+        variableValue("Keine POIs vorhanden")
+    }
+    appendNewline(2)
+
+    variableKey("Beschreibung:")
+    appendNewline()
+    variableValue(entry.description.ifBlank { "Keine Beschreibung vorhanden" })
+    appendNewline(2)
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -35,6 +35,9 @@ fun createSubmittedTourDialog(entry: TourEntry) = dialog {
 
             action(listMembersButton(entry))
             action(listPoIsButton(entry))
+
+            action(acceptButton(entry))
+            action(declineButton(entry))
         }
     }
 }
@@ -52,6 +55,35 @@ private fun backButton() = actionButton {
     }
 }
 
+private fun acceptButton(entry: TourEntry) = actionButton {
+    label { text("Annehmen") }
+    tooltip { info("Klicke, um die Tour zu genehmigen") }
+
+    action {
+        playerCallback {
+            plugin.launch {
+                entry.accept()
+            }
+            it.showDialog(createSubmittedTourMembersDialog(entry))
+        }
+    }
+}
+
+private fun declineButton(entry: TourEntry) = actionButton {
+    label { text("Ablehnen") }
+    tooltip { info("Klicke, um die Tour zu abzulehnen") }
+
+    action {
+        playerCallback {
+            plugin.launch {
+                entry.reject()
+            }
+            it.showDialog(createSubmittedTourMembersDialog(entry))
+        }
+    }
+}
+
+
 private fun listMembersButton(entry: TourEntry) = actionButton {
     label { text("Mitglieder") }
     tooltip { info("Zeige die Mitglieder der Einreichung an") }
@@ -62,8 +94,8 @@ private fun listMembersButton(entry: TourEntry) = actionButton {
 }
 
 private fun listPoIsButton(entry: TourEntry) = actionButton {
-    label { text("POIs") }
-    tooltip { info("Zeige die POIs der Einreichung an") }
+    label { text("PoIs") }
+    tooltip { info("Zeige die PoIs der Einreichung an") }
 
     action {
         playerCallback { it.showDialog(createSubmittedTourPoIsDialog(entry)) }
@@ -93,12 +125,12 @@ fun buildTourBody(entry: TourEntry) = buildText {
     }
     appendNewline(2)
 
-    val pois = entry.poi
+    val poIs = entry.poi
     variableKey("POIs ")
-    variableValue("(${pois.size})")
+    variableValue("(${poIs.size})")
     appendNewline()
-    if (pois.isNotEmpty()) {
-        variableValue(pois.joinToString(", ") { it.name })
+    if (poIs.isNotEmpty()) {
+        variableValue(poIs.joinToString(", ") { it.name })
     } else {
         variableValue("Keine POIs vorhanden")
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -3,6 +3,7 @@
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
 import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.servertour.dialogs.own.review.showcase.createShowcaseTourDialog
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
@@ -13,7 +14,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.registry.data.dialog.DialogBase
 
-fun createSubmittedTourDialog(entry: TourEntry) = dialog {
+fun createSubmittedTourDialog(entry: TourEntry, showcase: Boolean = false) = dialog {
     base {
         title {
             primary("Tourübersicht für ")
@@ -31,7 +32,7 @@ fun createSubmittedTourDialog(entry: TourEntry) = dialog {
     type {
         multiAction {
             columns(2)
-            exitAction(backButton())
+            exitAction(backButton(showcase))
 
             action(listMembersButton(entry))
             action(listPoIsButton(entry))
@@ -42,14 +43,14 @@ fun createSubmittedTourDialog(entry: TourEntry) = dialog {
     }
 }
 
-private fun backButton() = actionButton {
+private fun backButton(showcase: Boolean) = actionButton {
     label { error("Zurück") }
     tooltip { info("Zurück zu den Einreichungen") }
 
     action {
         playerCallback {
             plugin.launch {
-                it.showDialog(createViewSubmittedToursDialog())
+                it.showDialog(if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog())
             }
         }
     }
@@ -83,7 +84,7 @@ private fun declineButton(entry: TourEntry) = actionButton {
     }
 }
 
-private fun createEntryUpdatedNotice(accepted: Boolean) = dialog {
+private fun createEntryUpdatedNotice(accepted: Boolean, showcase: Boolean = false) = dialog {
     base {
         title { primary("Erfolgreich") }
         afterAction(DialogBase.DialogAfterAction.NONE)
@@ -106,7 +107,7 @@ private fun createEntryUpdatedNotice(accepted: Boolean) = dialog {
 
                     playerCallback {
                         plugin.launch {
-                            it.showDialog(createViewSubmittedToursDialog())
+                            it.showDialog(if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog())
                         }
                     }
                 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -34,8 +34,8 @@ fun createSubmittedTourDialog(entry: TourEntry, showcase: Boolean = false) = dia
             columns(2)
             exitAction(backButton(showcase))
 
-            action(listMembersButton(entry))
-            action(listPoIsButton(entry))
+            action(listMembersButton(entry, showcase))
+            action(listPoIsButton(entry, showcase))
 
             if (!showcase) {
                 action(acceptButton(entry))
@@ -119,21 +119,21 @@ private fun createEntryUpdatedNotice(accepted: Boolean, showcase: Boolean = fals
 }
 
 
-private fun listMembersButton(entry: TourEntry) = actionButton {
+private fun listMembersButton(entry: TourEntry, showcase: Boolean) = actionButton {
     label { text("Mitglieder") }
     tooltip { info("Zeige die Mitglieder der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(createSubmittedTourMembersDialog(entry)) }
+        playerCallback { it.showDialog(createSubmittedTourMembersDialog(entry, showcase)) }
     }
 }
 
-private fun listPoIsButton(entry: TourEntry) = actionButton {
+private fun listPoIsButton(entry: TourEntry, showcase: Boolean) = actionButton {
     label { text("PoIs") }
     tooltip { info("Zeige die PoIs der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(createSubmittedTourPoIsDialog(entry)) }
+        playerCallback { it.showDialog(createSubmittedTourPoIsDialog(entry, showcase)) }
     }
 }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -186,7 +186,7 @@ fun buildTourBody(entry: TourEntry) = buildText {
     variableValue("(${poIs.size})")
     appendNewline()
     if (poIs.isNotEmpty()) {
-        variableValue(poIs.joinToString(", ") { it.name })
+        variableValue(poIs.sortedBy { it.name }.joinToString(", ") { it.name })
     } else {
         variableValue("Keine POIs vorhanden")
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -122,7 +122,7 @@ private fun createEntryUpdatedNotice(accepted: Boolean, showcase: Boolean = fals
             notice {
                 action {
                     label { text("Zurück") }
-                    tooltip { info("Zurück zu dne Einreichungen") }
+                    tooltip { info("Zurück zu den Einreichungen") }
 
                     playerCallback {
                         plugin.launch {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -23,7 +23,7 @@ fun createSubmittedTourDialog(entry: TourEntry, showcase: Boolean = false) = dia
             primary("Tourübersicht für ")
             variableValue(entry.name)
         }
-        afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+        afterAction(DialogBase.DialogAfterAction.NONE)
 
         body {
             plainMessage(400) {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -3,7 +3,6 @@
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
 import com.github.shynixn.mccoroutine.folia.launch
-import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.dialogs.own.review.showcase.createShowcaseTourDialog
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
@@ -53,12 +52,7 @@ private fun backButton(showcase: Boolean) = actionButton {
     action {
         playerCallback {
             plugin.launch {
-                val dialog =
-                    if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog()
-                it.showDialog(dialog)
-                if (showcase) {
-                    SERVER_TOUR_LATEST_DIALOGS[it.uniqueId] = dialog
-                }
+                it.showDialog(if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog())
             }
         }
     }
@@ -131,9 +125,7 @@ private fun listMembersButton(entry: TourEntry, showcase: Boolean) = actionButto
 
     action {
         playerCallback {
-            val dialog = createSubmittedTourMembersDialog(entry, showcase)
-            it.showDialog(dialog)
-            SERVER_TOUR_LATEST_DIALOGS[it.uniqueId] = dialog
+            it.showDialog(createSubmittedTourMembersDialog(entry, showcase))
         }
     }
 }
@@ -144,9 +136,7 @@ private fun listPoIsButton(entry: TourEntry, showcase: Boolean) = actionButton {
 
     action {
         playerCallback {
-            val dialog = createSubmittedTourPoIsDialog(entry, showcase)
-            it.showDialog(dialog)
-            SERVER_TOUR_LATEST_DIALOGS[it.uniqueId] = dialog
+            it.showDialog(createSubmittedTourPoIsDialog(entry, showcase))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -3,6 +3,7 @@
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
 import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.dialogs.own.review.showcase.createShowcaseTourDialog
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.servertour.plugin
@@ -52,7 +53,12 @@ private fun backButton(showcase: Boolean) = actionButton {
     action {
         playerCallback {
             plugin.launch {
-                it.showDialog(if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog())
+                val dialog =
+                    if (showcase) createShowcaseTourDialog() else createViewSubmittedToursDialog()
+                it.showDialog(dialog)
+                if (showcase) {
+                    SERVER_TOUR_LATEST_DIALOGS[it.uniqueId] = dialog
+                }
             }
         }
     }
@@ -124,7 +130,11 @@ private fun listMembersButton(entry: TourEntry, showcase: Boolean) = actionButto
     tooltip { info("Zeige die Mitglieder der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(createSubmittedTourMembersDialog(entry, showcase)) }
+        playerCallback {
+            val dialog = createSubmittedTourMembersDialog(entry, showcase)
+            it.showDialog(dialog)
+            SERVER_TOUR_LATEST_DIALOGS[it.uniqueId] = dialog
+        }
     }
 }
 
@@ -133,7 +143,11 @@ private fun listPoIsButton(entry: TourEntry, showcase: Boolean) = actionButton {
     tooltip { info("Zeige die PoIs der Einreichung an") }
 
     action {
-        playerCallback { it.showDialog(createSubmittedTourPoIsDialog(entry, showcase)) }
+        playerCallback {
+            val dialog = createSubmittedTourPoIsDialog(entry, showcase)
+            it.showDialog(dialog)
+            SERVER_TOUR_LATEST_DIALOGS[it.uniqueId] = dialog
+        }
     }
 }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -43,7 +43,7 @@ fun createSubmittedTourDialog(entry: TourEntry) = dialog {
 }
 
 private fun backButton() = actionButton {
-    label { text("Zurück") }
+    label { error("Zurück") }
     tooltip { info("Zurück zu den Einreichungen") }
 
     action {
@@ -56,7 +56,7 @@ private fun backButton() = actionButton {
 }
 
 private fun acceptButton(entry: TourEntry) = actionButton {
-    label { text("Annehmen") }
+    label { success("Annehmen") }
     tooltip { info("Klicke, um die Tour zu genehmigen") }
 
     action {
@@ -70,7 +70,7 @@ private fun acceptButton(entry: TourEntry) = actionButton {
 }
 
 private fun declineButton(entry: TourEntry) = actionButton {
-    label { text("Ablehnen") }
+    label { error("Ablehnen") }
     tooltip { info("Klicke, um die Tour zu abzulehnen") }
 
     action {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -37,8 +37,10 @@ fun createSubmittedTourDialog(entry: TourEntry, showcase: Boolean = false) = dia
             action(listMembersButton(entry))
             action(listPoIsButton(entry))
 
-            action(acceptButton(entry))
-            action(declineButton(entry))
+            if (!showcase) {
+                action(acceptButton(entry))
+                action(declineButton(entry))
+            }
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -2,27 +2,22 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
-import dev.slne.surf.servertour.dialogs.own.buildOwnTourTitle
-import dev.slne.surf.servertour.dialogs.own.member.oneMemberDialog
-import dev.slne.surf.servertour.dialogs.own.ownTourDialog
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
-import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
-import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
 
-fun createSubmittedTourMembersDialog(entry: TourEntry): Dialog = dialog {
+fun createSubmittedTourMembersDialog(entry: TourEntry, showcase: Boolean = false): Dialog = dialog {
     base {
         title { primary("Mitglieder der Einreichung") }
         afterAction(DialogBase.DialogAfterAction.NONE)
 
         body {
             plainMessage(400) {
-                if(entry.members.isEmpty()) {
+                if (entry.members.isEmpty()) {
                     error("Keine Mitglieder")
                 } else {
                     variableKey("Mitglieder: ")
@@ -34,11 +29,11 @@ fun createSubmittedTourMembersDialog(entry: TourEntry): Dialog = dialog {
 
     type {
         if (entry.members.isEmpty()) {
-            notice(backButton(entry))
+            notice(backButton(entry, showcase))
         } else {
             multiAction {
                 columns(3)
-                exitAction(backButton(entry))
+                exitAction(backButton(entry, showcase))
 
                 entry.members.forEach {
                     action {
@@ -66,13 +61,13 @@ fun createSubmittedTourMembersDialog(entry: TourEntry): Dialog = dialog {
     }
 }
 
-private fun backButton(entry: TourEntry) = actionButton {
+private fun backButton(entry: TourEntry, showcase: Boolean) = actionButton {
     label { text("Zurück") }
     tooltip { info("Zurück zur Einreichung") }
 
     action {
         playerCallback { player ->
-            player.showDialog(createSubmittedTourDialog(entry))
+            player.showDialog(createSubmittedTourDialog(entry, showcase))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -46,7 +46,7 @@ fun createSubmittedTourMembersDialog(entry: TourEntry, showcase: Boolean = false
                             )
                         }
                         tooltip {
-                            variableKey("Beschreibung:")
+                            variableKey("Beschreibung: ")
                             it.description?.let { desc ->
                                 variableValue(desc)
                                 return@tooltip

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -2,7 +2,6 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
-import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
@@ -68,9 +67,7 @@ private fun backButton(entry: TourEntry, showcase: Boolean) = actionButton {
 
     action {
         playerCallback { player ->
-            val dialog = createSubmittedTourDialog(entry, showcase)
-            player.showDialog(dialog)
-            SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = dialog
+            player.showDialog(createSubmittedTourDialog(entry, showcase))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -1,0 +1,82 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.submitted
+
+import dev.slne.surf.servertour.dialogs.own.buildOwnTourTitle
+import dev.slne.surf.servertour.dialogs.own.member.oneMemberDialog
+import dev.slne.surf.servertour.dialogs.own.ownTourDialog
+import dev.slne.surf.servertour.entry.TourEntry
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+fun createSubmittedTourMembersDialog(entry: TourEntry): Dialog = dialog {
+    base {
+        title { primary("Mitglieder der Einreichung") }
+        afterAction(DialogBase.DialogAfterAction.NONE)
+
+        body {
+            plainMessage(400) {
+                if(entry.members.isEmpty()) {
+                    error("Keine Mitglieder")
+                } else {
+                    variableKey("Mitglieder: ")
+                    variableValue(entry.members.size)
+                }
+            }
+        }
+    }
+
+    type {
+        if (entry.members.isEmpty()) {
+            notice(backButton(entry))
+        } else {
+            multiAction {
+                columns(3)
+                exitAction(backButton(entry))
+
+                entry.members.forEach {
+                    action {
+                        width(200)
+
+                        label {
+                            text(
+                                it.offlinePlayer.name
+                                    ?: it.offlinePlayer.uniqueId.toString()
+                            )
+                        }
+                        tooltip {
+                            variableKey("Beschreibung:")
+                            appendNewline()
+                            appendNewline()
+
+                            it.description?.let { desc ->
+                                variableValue(desc)
+                                return@tooltip
+                            }
+
+                            variableValue("Keine Beschreibung")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun backButton(entry: TourEntry) = actionButton {
+    label { text("Zurück") }
+    tooltip { info("Zurück zur Einreichung") }
+
+    action {
+        playerCallback { player ->
+            player.showDialog(createSubmittedTourDialog(entry))
+        }
+    }
+}
+

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -52,9 +52,6 @@ fun createSubmittedTourMembersDialog(entry: TourEntry): Dialog = dialog {
                         }
                         tooltip {
                             variableKey("Beschreibung:")
-                            appendNewline()
-                            appendNewline()
-
                             it.description?.let { desc ->
                                 variableValue(desc)
                                 return@tooltip

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -2,6 +2,7 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
+import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
@@ -67,7 +68,9 @@ private fun backButton(entry: TourEntry, showcase: Boolean) = actionButton {
 
     action {
         playerCallback { player ->
-            player.showDialog(createSubmittedTourDialog(entry, showcase))
+            val dialog = createSubmittedTourDialog(entry, showcase)
+            player.showDialog(dialog)
+            SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = dialog
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourMembersDialog.kt
@@ -45,14 +45,14 @@ fun createSubmittedTourMembersDialog(entry: TourEntry, showcase: Boolean = false
                                     ?: it.offlinePlayer.uniqueId.toString()
                             )
                         }
-                        tooltip {
-                            variableKey("Beschreibung: ")
-                            it.description?.let { desc ->
-                                variableValue(desc)
-                                return@tooltip
+                        val description = it.description
+                        if (description != null && description.isNotBlank()) {
+                            tooltip {
+                                variableKey("Beschreibung: ")
+                                variableValue(description)
                             }
-
-                            variableValue("Keine Beschreibung")
+                        } else {
+                            tooltip { info("Ohne Beschreibung") }
                         }
                     }
                 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIDialog.kt
@@ -1,0 +1,68 @@
+@file:Suppress("UnstableApiUsage")
+@file:OptIn(NmsUseWithCaution::class)
+
+package dev.slne.surf.servertour.dialogs.own.review.submitted
+
+import dev.slne.surf.servertour.entry.Poi
+import dev.slne.surf.servertour.entry.TourEntry
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.clearDialogs
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+fun createSubmittedTourPoIDialog(entry: TourEntry, poi: Poi, showcase: Boolean = false) = dialog {
+    base {
+        title {
+            primary(entry.name)
+            spacer(" - ")
+            variableValue(poi.name)
+        }
+        afterAction(DialogBase.DialogAfterAction.NONE)
+
+        body {
+            plainMessage(400) {
+                variableKey("Besitzer: ")
+                appendNewline()
+                variableValue(poi.owner?.offlinePlayer?.name ?: "Nicht angegeben")
+                appendNewline(2)
+                variableKey("Beschreibung: ")
+                appendNewline()
+                variableValue(poi.description)
+            }
+        }
+    }
+
+    type {
+        multiAction {
+            action(teleportButton(poi))
+            exitAction(backButton(entry, showcase))
+        }
+    }
+}
+
+private fun teleportButton(poi: Poi) = actionButton {
+    label { info("Teleportieren") }
+    tooltip { info("Teleportiere dich zu diesem PoI") }
+
+    action {
+        playerCallback { player ->
+            player.teleportAsync(poi.location)
+            player.clearDialogs()
+        }
+    }
+}
+
+private fun backButton(entry: TourEntry, showcase: Boolean) = actionButton {
+    label { error("Zurück") }
+    tooltip { info("Zurück zu den PoIs") }
+
+    action {
+        playerCallback { player ->
+            player.showDialog(createSubmittedTourPoIsDialog(entry, showcase))
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -21,7 +21,7 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
 
         body {
             plainMessage(400) {
-                if(entry.members.isEmpty()) {
+                if (entry.members.isEmpty()) {
                     error("Keine PoIs")
                 } else {
                     variableKey("PoIs: ")
@@ -67,7 +67,7 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
 }
 
 private fun backButton(entry: TourEntry) = actionButton {
-    label { text("Zurück") }
+    label { error("Zurück") }
     tooltip { info("Zurück zur Einreichung") }
 
     action {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -1,12 +1,15 @@
 @file:Suppress("UnstableApiUsage")
+@file:OptIn(NmsUseWithCaution::class)
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.clearDialogs
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
@@ -42,7 +45,7 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
                         tooltip {
                             variableKey("Besitzer: ")
                             variableValue(it.owner?.offlinePlayer?.name ?: "Nicht angegeben")
-                            appendNewline(2)
+                            appendNewline()
                             variableKey("Beschreibung: ")
                             variableValue(it.description)
                             appendNewline(2)
@@ -51,7 +54,10 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
                         width(200)
 
                         action {
-                            playerCallback { player -> player.teleportAsync(it.location) }
+                            playerCallback { player ->
+                                player.teleportAsync(it.location)
+                                player.clearDialogs()
+                            }
                         }
                     }
                 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -20,7 +20,7 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry, showcase: Boolean = false): 
 
         body {
             plainMessage(400) {
-                if (entry.members.isEmpty()) {
+                if (entry.poi.isEmpty()) {
                     error("Keine PoIs")
                 } else {
                     variableKey("PoIs: ")

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -3,6 +3,7 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
+import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
@@ -47,7 +48,9 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry, showcase: Boolean = false): 
 
                         action {
                             playerCallback { player ->
-                                player.showDialog(createSubmittedTourPoIDialog(entry, it, showcase))
+                                val dialog = createSubmittedTourPoIDialog(entry, it, showcase)
+                                player.showDialog(dialog)
+                                SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = dialog
                             }
                         }
                     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -6,11 +6,9 @@ package dev.slne.surf.servertour.dialogs.own.review.submitted
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
-import dev.slne.surf.surfapi.bukkit.api.dialog.clearDialogs
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
 import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
-import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
 
@@ -43,20 +41,13 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry, showcase: Boolean = false): 
                     action {
                         label { text(it.name) }
                         tooltip {
-                            variableKey("Besitzer: ")
-                            variableValue(it.owner?.offlinePlayer?.name ?: "Nicht angegeben")
-                            appendNewline()
-                            variableKey("Beschreibung: ")
-                            variableValue(it.description)
-                            appendNewline(2)
-                            spacer("Klicke, um dich zum PoI zu teleportieren")
+                            spacer("Klicke, um genauere Informationen zu diesem PoI anzusehen")
                         }
                         width(200)
 
                         action {
                             playerCallback { player ->
-                                player.teleportAsync(it.location)
-                                player.clearDialogs()
+                                player.showDialog(createSubmittedTourPoIDialog(entry, it, showcase))
                             }
                         }
                     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -9,6 +9,7 @@ import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
 import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -14,7 +14,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
 
-fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
+fun createSubmittedTourPoIsDialog(entry: TourEntry, showcase: Boolean = false): Dialog = dialog {
     base {
         title { primary("PoIs der Einreichung") }
         afterAction(DialogBase.DialogAfterAction.NONE)
@@ -33,11 +33,11 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
 
     type {
         if (entry.poi.isEmpty()) {
-            notice(backButton(entry))
+            notice(backButton(entry, showcase))
         } else {
             multiAction {
                 columns(3)
-                exitAction(backButton(entry))
+                exitAction(backButton(entry, showcase))
 
                 entry.poi.forEach {
                     action {
@@ -66,13 +66,13 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
     }
 }
 
-private fun backButton(entry: TourEntry) = actionButton {
+private fun backButton(entry: TourEntry, showcase: Boolean) = actionButton {
     label { error("Zurück") }
     tooltip { info("Zurück zur Einreichung") }
 
     action {
         playerCallback { player ->
-            player.showDialog(createSubmittedTourDialog(entry))
+            player.showDialog(createSubmittedTourDialog(entry, showcase))
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -1,0 +1,74 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.submitted
+
+import dev.slne.surf.servertour.entry.TourEntry
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+fun createSubmittedTourPoIsDialog(entry: TourEntry): Dialog = dialog {
+    base {
+        title { primary("PoIs der Einreichung") }
+        afterAction(DialogBase.DialogAfterAction.NONE)
+
+        body {
+            plainMessage(400) {
+                if(entry.members.isEmpty()) {
+                    error("Keine PoIs")
+                } else {
+                    variableKey("PoIs: ")
+                    variableValue(entry.poi.size)
+                }
+            }
+        }
+    }
+
+    type {
+        if (entry.poi.isEmpty()) {
+            notice(backButton(entry))
+        } else {
+            multiAction {
+                columns(3)
+                exitAction(backButton(entry))
+
+                entry.poi.forEach {
+                    action {
+                        label { text(it.name) }
+                        tooltip {
+                            variableKey("Besitzer: ")
+                            variableValue(it.owner?.offlinePlayer?.name ?: "Nicht angegeben")
+                            appendNewline(2)
+                            variableKey("Beschreibung: ")
+                            variableValue(it.description)
+                            appendNewline(2)
+                            spacer("Klicke, um dich zum PoI zu teleportieren")
+                        }
+                        width(200)
+
+                        action {
+                            playerCallback { player -> player.teleportAsync(it.location) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun backButton(entry: TourEntry) = actionButton {
+    label { text("Zurück") }
+    tooltip { info("Zurück zur Einreichung") }
+
+    action {
+        playerCallback { player ->
+            player.showDialog(createSubmittedTourDialog(entry))
+        }
+    }
+}
+
+

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourPoIsDialog.kt
@@ -3,7 +3,6 @@
 
 package dev.slne.surf.servertour.dialogs.own.review.submitted
 
-import dev.slne.surf.servertour.dialogs.SERVER_TOUR_LATEST_DIALOGS
 import dev.slne.surf.servertour.entry.TourEntry
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
@@ -48,9 +47,7 @@ fun createSubmittedTourPoIsDialog(entry: TourEntry, showcase: Boolean = false): 
 
                         action {
                             playerCallback { player ->
-                                val dialog = createSubmittedTourPoIDialog(entry, it, showcase)
-                                player.showDialog(dialog)
-                                SERVER_TOUR_LATEST_DIALOGS[player.uniqueId] = dialog
+                                player.showDialog(createSubmittedTourPoIDialog(entry, it, showcase))
                             }
                         }
                     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/ViewSubmittedToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/ViewSubmittedToursDialog.kt
@@ -1,0 +1,82 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.submitted
+
+import dev.slne.surf.servertour.dialogs.serverTourDialog
+import dev.slne.surf.servertour.entry.EntryManager
+import dev.slne.surf.servertour.entry.EntryStatus
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.util.toObjectList
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+suspend fun createViewSubmittedToursDialog(): Dialog {
+    val submittedTours = EntryManager.listEntries()
+        .filter { it.status == EntryStatus.PENDING }
+        .sortedBy {
+            it.name
+        }
+        .map {
+            it to createSubmittedTourDialog(it)
+        }
+        .toObjectList()
+    return dialog {
+        base {
+            title { primary("Einreichungen") }
+            afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+
+            if (submittedTours.isEmpty()) {
+                body {
+                    plainMessage(400) {
+                        error("Es wurden keine Einreichungen gefunden")
+                    }
+                }
+            }
+        }
+
+        type {
+            if (submittedTours.isEmpty()) {
+                notice {
+                    label { text("Zurück") }
+                    tooltip { info("Zurück zum Hauptmenü") }
+
+                    action {
+                        playerCallback {
+                            it.showDialog(serverTourDialog(it.uniqueId))
+                        }
+                    }
+                }
+            } else {
+                multiAction {
+                    columns(3)
+
+                    submittedTours.forEach {
+                        action {
+                            label { text(it.first.name) }
+                            tooltip { info("Einreichung ansehen: ${it.first.name}") }
+
+                            action {
+                                playerCallback { player ->
+                                    player.showDialog(it.second)
+                                }
+                            }
+                        }
+                    }
+
+                    exitAction {
+                        label { text("Zurück") }
+                        tooltip { info("Zurück zum Hauptmenü") }
+
+                        action {
+                            playerCallback {
+                                it.showDialog(serverTourDialog(it.uniqueId))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/ViewSubmittedToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/ViewSubmittedToursDialog.kt
@@ -39,7 +39,7 @@ suspend fun createViewSubmittedToursDialog(): Dialog {
         type {
             if (submittedTours.isEmpty()) {
                 notice {
-                    label { text("Zurück") }
+                    label { error("Zurück") }
                     tooltip { info("Zurück zum Hauptmenü") }
 
                     action {
@@ -54,7 +54,7 @@ suspend fun createViewSubmittedToursDialog(): Dialog {
 
                     submittedTours.forEach {
                         action {
-                            label { text(it.first.name) }
+                            label { variableKey(it.first.name) }
                             tooltip { info("Einreichung ansehen: ${it.first.name}") }
 
                             action {
@@ -66,7 +66,7 @@ suspend fun createViewSubmittedToursDialog(): Dialog {
                     }
 
                     exitAction {
-                        label { text("Zurück") }
+                        label { error("Zurück") }
                         tooltip { info("Zurück zum Hauptmenü") }
 
                         action {

--- a/src/main/kotlin/dev/slne/surf/servertour/entry/EntryManager.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/entry/EntryManager.kt
@@ -23,6 +23,11 @@ object EntryManager {
             .map { it.toApi() }
     }
 
+    suspend fun listEntries() = newSuspendedTransaction(Dispatchers.IO) {
+        EntryModel.find { EntryTable.server eq config.serverName }
+            .map { it.toApi() }
+    }
+
     suspend fun createEntry(entry: TourEntry) = newSuspendedTransaction(Dispatchers.IO) {
         val dbEntry = EntryModel.new {
             this.server = entry.server

--- a/src/main/kotlin/dev/slne/surf/servertour/utils/ServerTourPermissionRegistry.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/utils/ServerTourPermissionRegistry.kt
@@ -8,4 +8,5 @@ object ServerTourPermissionRegistry : PermissionRegistry() {
     private const val COMMAND_PREFIX = "$PREFIX.command"
 
     val BASE = create("$COMMAND_PREFIX.base")
+    val REVIEWER = create("$PREFIX.reviewer")
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/utils/ServerTourPermissionRegistry.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/utils/ServerTourPermissionRegistry.kt
@@ -9,4 +9,5 @@ object ServerTourPermissionRegistry : PermissionRegistry() {
 
     val BASE = create("$COMMAND_PREFIX.base")
     val REVIEWER = create("$PREFIX.reviewer")
+    val SHOWCASE = create("$PREFIX.showcase")
 }

--- a/src/main/kotlin/dev/slne/surf/servertour/utils/permission-holder-util.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/utils/permission-holder-util.kt
@@ -1,0 +1,6 @@
+package dev.slne.surf.servertour.utils
+
+import org.bukkit.Bukkit
+import java.util.UUID
+
+fun UUID.hasPermission(permission: String) = Bukkit.getPlayer(this)?.hasPermission(permission) ?: false


### PR DESCRIPTION
This pull request introduces a new review and showcase workflow for server tour submissions, reorganizes and renames several dialog-related functions for clarity, and improves the user interface for managing tour entries, members, and points of interest (POIs). It also bumps the project version and makes minor improvements to sorting and labeling.

**New review and showcase workflow:**

* Added new dialogs for reviewing and showcasing server tour submissions:
  - `createShowcaseTourDialog` allows users to view all accepted submissions in a showcase format.
  - `createSubmittedTourDialog` provides an interface for reviewing individual submissions, with actions for accepting, declining, teleporting, and viewing members/POIs.
  - `createSubmittedTourMembersDialog` enables viewing members of a submitted tour, including descriptions and navigation.
  - `createViewSubmittedToursDialog` (referenced in dialog actions) allows reviewers to see all submissions awaiting review.
* Added permission checks to display reviewer and showcase actions only to users with the appropriate permissions in the main tour dialog.
* Added logic to remember and resume the last viewed tour for each user via `SERVER_TOUR_LAST_VIEWED`. [[1]](diffhunk://#diff-0a83111b98d0ddd51a02e904d06d4e4c5df334b57c388f03bce2e51f2e68d7a9R7-R24) [[2]](diffhunk://#diff-0a83111b98d0ddd51a02e904d06d4e4c5df334b57c388f03bce2e51f2e68d7a9L24-R54)

**Dialog and codebase refactoring:**

* Renamed dialog functions for clarity and consistency:
  - `ownTourMembersDialog` → `createTourMembersDialog` [[1]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250L11-R13) [[2]](diffhunk://#diff-d451f06c3feb57e5ba1dea39048c6e625df4b4c4e79c2c098198ae9b7c73f178L16-R16) [[3]](diffhunk://#diff-027f6d9aacfb92d5c74d2b069b4b7271c8c7068384228955e97c76970677c3c5L69-R69) [[4]](diffhunk://#diff-2cc8f27dae56e555e83ad696395a70c038470f01d3b897e30696c1efb2e85defL63-R63)
  - `ownTourPoisDialog` → `createTourPoIsDialog` [[1]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250L11-R13) [[2]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250L229-R229) [[3]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49L124-R124) [[4]](diffhunk://#diff-3646db3d12699e34695eeb8a4e4d1129fa8ec27532b6ee490fa44a8306cfe057L60-R60)
* Updated all usages to the new function names across the codebase. [[1]](diffhunk://#diff-10ca47f2bd9e3f5b05664ea434bba6ee0b6a38bd0b16b13d2fd88121385cf250L247-R247) [[2]](diffhunk://#diff-027f6d9aacfb92d5c74d2b069b4b7271c8c7068384228955e97c76970677c3c5L69-R69) [[3]](diffhunk://#diff-2cc8f27dae56e555e83ad696395a70c038470f01d3b897e30696c1efb2e85defL63-R63) [[4]](diffhunk://#diff-27546053329bc09442c8f8c907f48378d493b2f0cf8fb6056c64b4b8cfc54b49L124-R124) [[5]](diffhunk://#diff-3646db3d12699e34695eeb8a4e4d1129fa8ec27532b6ee490fa44a8306cfe057L60-R60)

**User interface and usability improvements:**

* Improved labeling and sorting:
  - Updated button labels to use more informative or styled text (e.g., `info`, `success`, `variableValue`). [[1]](diffhunk://#diff-0a83111b98d0ddd51a02e904d06d4e4c5df334b57c388f03bce2e51f2e68d7a9R64-R76) [[2]](diffhunk://#diff-0a83111b98d0ddd51a02e904d06d4e4c5df334b57c388f03bce2e51f2e68d7a9R86-R111)
  - POIs are now sorted alphabetically in the tour body display.
* Increased the number of columns in the main dialog from 1 to 2 for better layout.

**Versioning:**

* Bumped project version to `1.21.7-1.0.2-SNAPSHOT`.