### PR TITLE
Feat/update showcase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.0.2-SNAPSHOT
+version=1.21.7-1.0.3-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -46,7 +46,9 @@ fun serverTourDialog(owner: UUID) = dialog {
             }
 
             SERVER_TOUR_LAST_VIEWED[owner]?.let {
-                action(createResumeTourButton(it))
+                if (owner.hasPermission(ServerTourPermissionRegistry.SHOWCASE)) {
+                    action(createResumeTourButton(it))
+                }
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/ServerTourDialog.kt
@@ -5,6 +5,7 @@ package dev.slne.surf.servertour.dialogs
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.servertour.dialogs.own.createOwnTourDialog
 import dev.slne.surf.servertour.dialogs.own.review.showcase.createShowcaseTourDialog
+import dev.slne.surf.servertour.dialogs.own.review.showcase.createSortShowcaseToursDialog
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTourDialog
 import dev.slne.surf.servertour.dialogs.own.review.submitted.createViewSubmittedToursDialog
 import dev.slne.surf.servertour.entry.TourEntry
@@ -37,6 +38,7 @@ fun serverTourDialog(owner: UUID) = dialog {
 
             if (owner.hasPermission(ServerTourPermissionRegistry.REVIEWER)) {
                 action(createViewSubmittedToursButton())
+                action(createSortSubmittedToursButton())
             }
 
             if (owner.hasPermission(ServerTourPermissionRegistry.SHOWCASE)) {
@@ -105,6 +107,19 @@ private fun createViewSubmittedToursButton(): ActionButton = actionButton {
         playerCallback { player ->
             plugin.launch {
                 player.showDialog(createViewSubmittedToursDialog())
+            }
+        }
+    }
+}
+
+private fun createSortSubmittedToursButton(): ActionButton = actionButton {
+    label { variableValue("Einreichungen sortieren") }
+    tooltip { info("Sortiere alle genehmigten Einreichungen") }
+
+    action {
+        playerCallback { player ->
+            plugin.launch {
+                player.showDialog(createSortShowcaseToursDialog())
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -56,7 +56,7 @@ suspend fun createShowcaseTourDialog(): Dialog {
 
                     acceptedTours.forEach {
                         action {
-                            width(200)
+                            width(300)
                             label { variableKey(it.first.name) }
                             tooltip { info("Einreichung ansehen: ${it.first.name}") }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -52,11 +52,11 @@ suspend fun createShowcaseTourDialog(): Dialog {
                 }
             } else {
                 multiAction {
-                    columns(1)
+                    columns(2)
 
                     acceptedTours.forEach {
                         action {
-                            width(300)
+                            width(200)
                             label { variableKey(it.first.name) }
                             tooltip { info("Einreichung ansehen: ${it.first.name}") }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -7,9 +7,11 @@ import dev.slne.surf.servertour.dialogs.own.review.submitted.createSubmittedTour
 import dev.slne.surf.servertour.dialogs.serverTourDialog
 import dev.slne.surf.servertour.entry.EntryManager
 import dev.slne.surf.servertour.entry.EntryStatus
+import dev.slne.surf.servertour.utils.appendEmDash
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.util.toObjectList
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
@@ -58,7 +60,26 @@ suspend fun createShowcaseTourDialog(): Dialog {
                         action {
                             width(200)
                             label { variableKey(it.first.name) }
-                            tooltip { info("Einreichung ansehen: ${it.first.name}") }
+                            tooltip {
+                                appendEmDash()
+                                variableKey("Name: ")
+                                variableValue(it.first.name)
+                                appendNewline()
+                                appendEmDash()
+                                variableKey("Status: ")
+                                variableValue(
+                                    it.first.status.name.lowercase()
+                                        .replaceFirstChar { char -> char.uppercase() })
+                                appendNewline()
+                                appendEmDash()
+                                variableKey("Besitzer: ")
+                                variableValue(
+                                    it.first.owner.offlinePlayer.name
+                                        ?: it.first.owner.uuid.toString()
+                                )
+                                appendNewline(2)
+                                spacer("Klicke, um die Einreichung anzusehen.")
+                            }
 
                             action {
                                 playerCallback { player ->

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/ShowcaseToursDialog.kt
@@ -52,10 +52,11 @@ suspend fun createShowcaseTourDialog(): Dialog {
                 }
             } else {
                 multiAction {
-                    columns(3)
+                    columns(1)
 
                     acceptedTours.forEach {
                         action {
+                            width(200)
                             label { variableKey(it.first.name) }
                             tooltip { info("Einreichung ansehen: ${it.first.name}") }
 

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseTourDialog.kt
@@ -74,6 +74,8 @@ private fun confirmSortButton(
                     variableValue(newName)
                     success(" umbenannt.")
                 }
+
+                clicker.showDialog(createSortShowcaseToursDialog())
             }
         }
     }

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseTourDialog.kt
@@ -1,0 +1,93 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.showcase
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.servertour.entry.EntryManager
+import dev.slne.surf.servertour.entry.TourEntry
+import dev.slne.surf.servertour.plugin
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.builder.actionButton
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+suspend fun createSortShowcaseTourDialog(entry: TourEntry) = dialog {
+    base {
+        title { primary("Einreichungen") }
+        afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+
+        body {
+            plainMessage {
+                info("Setze Nummern vor die Einreichungen, um diese zu sortieren.")
+                appendNewline()
+                info("Die Einträge werden aufsteigend sortiert.")
+            }
+        }
+
+        input {
+            text("name") {
+                label { text("Name") }
+                maxLength(64)
+                initial(entry.name)
+                width(600)
+            }
+        }
+    }
+
+    type {
+        confirmation(
+            confirmSortButton(entry),
+            cancelSortButton()
+        )
+    }
+}
+
+private fun confirmSortButton(
+    entry: TourEntry
+) = actionButton {
+    label { success("Speichern") }
+    tooltip { info("Speichern und zurück zum POI") }
+
+    action {
+        customClick { response, clicker ->
+            val newName = response.getText("name") ?: run {
+                clicker.sendText {
+                    appendPrefix()
+                    error("Der Name darf nicht leer sein.")
+                }
+                return@customClick
+            }
+
+            plugin.launch {
+                val oldName = entry.name
+                EntryManager.updateEntry(entry) {
+                    it.name = newName
+                }
+
+                clicker.sendText {
+                    appendPrefix()
+                    success("Die Einreichung wurde von ")
+                    variableValue(oldName)
+                    success(" zu ")
+                    variableValue(newName)
+                    success(" umbenannt.")
+                }
+            }
+        }
+    }
+}
+
+private fun cancelSortButton() = actionButton {
+    label { text("Abbrechen") }
+    tooltip { info("Abbrechen und zurück zur Übersicht") }
+
+    action {
+        playerCallback {
+            plugin.launch {
+                it.showDialog(createSortShowcaseToursDialog())
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseToursDialog.kt
@@ -5,9 +5,11 @@ package dev.slne.surf.servertour.dialogs.own.review.showcase
 import dev.slne.surf.servertour.dialogs.serverTourDialog
 import dev.slne.surf.servertour.entry.EntryManager
 import dev.slne.surf.servertour.entry.EntryStatus
+import dev.slne.surf.servertour.utils.appendEmDash
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.util.toObjectList
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
@@ -55,7 +57,26 @@ suspend fun createSortShowcaseToursDialog(): Dialog {
                     submittedTours.forEach {
                         action {
                             label { variableKey(it.first.name) }
-                            tooltip { info("Einreichung neusortieren: ${it.first.name}") }
+                            tooltip {
+                                appendEmDash()
+                                variableKey("Name: ")
+                                variableValue(it.first.name)
+                                appendNewline()
+                                appendEmDash()
+                                variableKey("Status: ")
+                                variableValue(
+                                    it.first.status.name.lowercase()
+                                        .replaceFirstChar { char -> char.uppercase() })
+                                appendNewline()
+                                appendEmDash()
+                                variableKey("Besitzer: ")
+                                variableValue(
+                                    it.first.owner.offlinePlayer.name
+                                        ?: it.first.owner.uuid.toString()
+                                )
+                                appendNewline(2)
+                                spacer("Klicke, um die Einreichung neu anzuordnen.")
+                            }
 
                             action {
                                 playerCallback { player ->

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/showcase/SortShowcaseToursDialog.kt
@@ -1,0 +1,82 @@
+@file:Suppress("UnstableApiUsage")
+
+package dev.slne.surf.servertour.dialogs.own.review.showcase
+
+import dev.slne.surf.servertour.dialogs.serverTourDialog
+import dev.slne.surf.servertour.entry.EntryManager
+import dev.slne.surf.servertour.entry.EntryStatus
+import dev.slne.surf.surfapi.bukkit.api.dialog.base
+import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
+import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.util.toObjectList
+import io.papermc.paper.dialog.Dialog
+import io.papermc.paper.registry.data.dialog.DialogBase
+
+suspend fun createSortShowcaseToursDialog(): Dialog {
+    val submittedTours = EntryManager.listEntries()
+        .filter { it.status == EntryStatus.ACCEPTED }
+        .sortedBy {
+            it.name
+        }
+        .map {
+            it to createSortShowcaseTourDialog(it)
+        }
+        .toObjectList()
+    return dialog {
+        base {
+            title { primary("Genehmigte Einreichungen") }
+            afterAction(DialogBase.DialogAfterAction.WAIT_FOR_RESPONSE)
+
+            if (submittedTours.isEmpty()) {
+                body {
+                    plainMessage(400) {
+                        error("Es wurden keine Einreichungen gefunden")
+                    }
+                }
+            }
+        }
+
+        type {
+            if (submittedTours.isEmpty()) {
+                notice {
+                    label { error("Zurück") }
+                    tooltip { info("Zurück zum Hauptmenü") }
+
+                    action {
+                        playerCallback {
+                            it.showDialog(serverTourDialog(it.uniqueId))
+                        }
+                    }
+                }
+            } else {
+                multiAction {
+                    columns(3)
+
+                    submittedTours.forEach {
+                        action {
+                            label { variableKey(it.first.name) }
+                            tooltip { info("Einreichung neusortieren: ${it.first.name}") }
+
+                            action {
+                                playerCallback { player ->
+                                    player.showDialog(it.second)
+                                }
+                            }
+                        }
+                    }
+
+                    exitAction {
+                        label { error("Zurück") }
+                        tooltip { info("Zurück zum Hauptmenü") }
+
+                        action {
+                            playerCallback {
+                                it.showDialog(serverTourDialog(it.uniqueId))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/SubmittedTourDialog.kt
@@ -182,7 +182,7 @@ fun buildTourBody(entry: TourEntry) = buildText {
     appendNewline(2)
 
     val poIs = entry.poi
-    variableKey("POIs:")
+    variableKey("POIs ")
     variableValue("(${poIs.size})")
     appendNewline()
     if (poIs.isNotEmpty()) {

--- a/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/ViewSubmittedToursDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/dialogs/own/review/submitted/ViewSubmittedToursDialog.kt
@@ -5,9 +5,11 @@ package dev.slne.surf.servertour.dialogs.own.review.submitted
 import dev.slne.surf.servertour.dialogs.serverTourDialog
 import dev.slne.surf.servertour.entry.EntryManager
 import dev.slne.surf.servertour.entry.EntryStatus
+import dev.slne.surf.servertour.utils.appendEmDash
 import dev.slne.surf.surfapi.bukkit.api.dialog.base
 import dev.slne.surf.surfapi.bukkit.api.dialog.dialog
 import dev.slne.surf.surfapi.bukkit.api.dialog.type
+import dev.slne.surf.surfapi.core.api.messages.adventure.appendNewline
 import dev.slne.surf.surfapi.core.api.util.toObjectList
 import io.papermc.paper.dialog.Dialog
 import io.papermc.paper.registry.data.dialog.DialogBase
@@ -55,7 +57,26 @@ suspend fun createViewSubmittedToursDialog(): Dialog {
                     submittedTours.forEach {
                         action {
                             label { variableKey(it.first.name) }
-                            tooltip { info("Einreichung ansehen: ${it.first.name}") }
+                            tooltip {
+                                appendEmDash()
+                                variableKey("Name: ")
+                                variableValue(it.first.name)
+                                appendNewline()
+                                appendEmDash()
+                                variableKey("Status: ")
+                                variableValue(
+                                    it.first.status.name.lowercase()
+                                        .replaceFirstChar { char -> char.uppercase() })
+                                appendNewline()
+                                appendEmDash()
+                                variableKey("Besitzer: ")
+                                variableValue(
+                                    it.first.owner.offlinePlayer.name
+                                        ?: it.first.owner.uuid.toString()
+                                )
+                                appendNewline(2)
+                                spacer("Klicke, um die Einreichung anzusehen.")
+                            }
 
                             action {
                                 playerCallback { player ->

--- a/src/main/kotlin/dev/slne/surf/servertour/utils/component-utils.kt
+++ b/src/main/kotlin/dev/slne/surf/servertour/utils/component-utils.kt
@@ -1,0 +1,6 @@
+package dev.slne.surf.servertour.utils
+
+import dev.slne.surf.surfapi.core.api.messages.CommonComponents
+import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
+
+fun SurfComponentBuilder.appendEmDash() = append(CommonComponents.EM_DASH).appendSpace()


### PR DESCRIPTION
This pull request adds a new dialog flow for sorting and renaming approved tour submissions, primarily targeting users with reviewer permissions. The main changes introduce dialogs for listing, sorting, and renaming approved ("showcase") tour entries, and update the UI to provide access to these features.

**New sorting and renaming functionality for approved tours:**

* Added `createSortShowcaseToursDialog` and `createSortShowcaseTourDialog` dialogs to allow reviewers to view, sort, and rename approved tour submissions. These dialogs display all accepted entries, allow renaming, and provide navigation back to the main menu. [[1]](diffhunk://#diff-0b3b5a6e026b01a1fce80b27fe38810fdfbf5f679a49050d0d7e20493a398063R1-R95) [[2]](diffhunk://#diff-88bfc967cb608afa9143fc251673d7f6ca96ea14f9daa4bd27caa44fcc3a509fR1-R82)

**UI and permission improvements:**

* Updated `serverTourDialog` to add a "Sort Submissions" button (visible to reviewers) that opens the new sorting dialog. [[1]](diffhunk://#diff-0a83111b98d0ddd51a02e904d06d4e4c5df334b57c388f03bce2e51f2e68d7a9R41) [[2]](diffhunk://#diff-0a83111b98d0ddd51a02e904d06d4e4c5df334b57c388f03bce2e51f2e68d7a9R114-R126)
* Imported the new dialog in `ServerTourDialog.kt`.

**UI layout tweaks:**

* Changed the column layout in `ShowcaseToursDialog.kt` from three columns to one, and set a fixed width for action buttons to improve display.