### PR TITLE
fix: update version to 1.21.7-1.1.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.7-1.0.3-SNAPSHOT
+version=1.21.7-1.1.0-SNAPSHOT


### PR DESCRIPTION
This pull request makes a minor update to the project version in `gradle.properties`, incrementing it from `1.21.7-1.0.3-SNAPSHOT` to `1.21.7-1.1.0-SNAPSHOT`.